### PR TITLE
hotfix(552): feature auth broken observers for emitting new intent events

### DIFF
--- a/android-deeplink/src/main/kotlin/co/anitrend/deeplink/component/route/AppRoutes.kt
+++ b/android-deeplink/src/main/kotlin/co/anitrend/deeplink/component/route/AppRoutes.kt
@@ -174,25 +174,26 @@ internal object OAuthRoute : Route(
         return runCatching {
             AuthRouter.Param(
                 accessToken =
-                    requireNotNull(queryParameter(CALLBACK_QUERY_TOKEN_KEY)) {
-                        "$CALLBACK_QUERY_TOKEN_KEY was not found in -> $fullyQualifiedUrl"
-                    },
+                requireNotNull(queryParameter(CALLBACK_QUERY_TOKEN_KEY)) {
+                    "$CALLBACK_QUERY_TOKEN_KEY was not found in -> $fullyQualifiedUrl"
+                },
                 tokenType =
-                    requireNotNull(queryParameter(CALLBACK_QUERY_TOKEN_TYPE_KEY)) {
-                        "$CALLBACK_QUERY_TOKEN_TYPE_KEY was not found in -> $fullyQualifiedUrl"
-                    },
+                requireNotNull(queryParameter(CALLBACK_QUERY_TOKEN_TYPE_KEY)) {
+                    "$CALLBACK_QUERY_TOKEN_TYPE_KEY was not found in -> $fullyQualifiedUrl"
+                },
                 expiresIn =
-                    requireNotNull(queryParameter(CALLBACK_QUERY_TOKEN_EXPIRES_IN_KEY)) {
-                        "$CALLBACK_QUERY_TOKEN_EXPIRES_IN_KEY was not found in -> $fullyQualifiedUrl"
-                    }.toLong(),
-            )
-        }.getOrElse {
-            Timber.w(it)
-            AuthRouter.Param(
-                errorTitle = queryParameter(CALLBACK_QUERY_ERROR_KEY),
-                errorDescription = queryParameter(CALLBACK_QUERY_ERROR_DESCRIPTION_KEY),
+                requireNotNull(queryParameter(CALLBACK_QUERY_TOKEN_EXPIRES_IN_KEY)) {
+                    "$CALLBACK_QUERY_TOKEN_EXPIRES_IN_KEY was not found in -> $fullyQualifiedUrl"
+                }.toLong(),
             )
         }
+            .onFailure(Timber::w)
+            .getOrDefault(
+                AuthRouter.Param(
+                    errorTitle = queryParameter(CALLBACK_QUERY_ERROR_KEY),
+                    errorDescription = queryParameter(CALLBACK_QUERY_ERROR_DESCRIPTION_KEY),
+                )
+            )
     }
 
     private fun DeepLinkUri.normalize(): Uri {

--- a/feature-auth/src/main/kotlin/co/anitrend/auth/component/content/AuthContent.kt
+++ b/feature-auth/src/main/kotlin/co/anitrend/auth/component/content/AuthContent.kt
@@ -129,10 +129,9 @@ class AuthContent(
             requireBinding().stateLayout.loadStateFlow.value = it
         }
         viewModelState().model.observeOnce(viewLifecycleOwner) { user ->
-            if (user != null) {
+            runCatching {
                 presenter.runSignInWorker(user.id)
-                activity?.finish()
-            } else {
+            }.onFailure {
                 Snackbar.make(
                     requireView(),
                     R.string.auth_failed_message,
@@ -141,6 +140,8 @@ class AuthContent(
                     presenter.runSignOutWorker()
                     closeScreen()
                 }.show()
+            }.onSuccess {
+                activity?.onBackPressed()
             }
         }
     }

--- a/feature-auth/src/main/kotlin/co/anitrend/auth/component/content/AuthContent.kt
+++ b/feature-auth/src/main/kotlin/co/anitrend/auth/component/content/AuthContent.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import timber.log.Timber
 
 class AuthContent(
@@ -50,7 +50,7 @@ class AuthContent(
 
     private val presenter by inject<AuthPresenter>()
 
-    private val viewModel by sharedViewModel<AuthViewModel>()
+    private val viewModel by activityViewModel<AuthViewModel>()
 
     private val resetNetworkStateOnBackPress =
         object : OnBackPressedCallback(true) {

--- a/feature-auth/src/main/kotlin/co/anitrend/auth/component/screen/AuthScreen.kt
+++ b/feature-auth/src/main/kotlin/co/anitrend/auth/component/screen/AuthScreen.kt
@@ -37,10 +37,9 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 class AuthScreen : AniTrendScreen<AuthScreenBinding>() {
 
     private val viewModel by viewModel<AuthViewModel>()
+    private val authRouterParam by extra<AuthRouter.Param>(AuthRouter.Param.KEY)
 
     private fun checkIntentData() {
-        val key = AuthRouter.Param.KEY
-        val authRouterParam by extra<AuthRouter.Param>(key)
         viewModel.onIntentData(
             applicationContext,
             authRouterParam
@@ -62,11 +61,6 @@ class AuthScreen : AniTrendScreen<AuthScreenBinding>() {
     override fun initializeComponents(savedInstanceState: Bundle?) {
         lifecycleScope.launch {
             onUpdateUserInterface()
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                checkIntentData()
-            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,12 +55,12 @@ jetbrains-kotlinx-coroutines = "1.8.0"
 jetbrains-kotlinx-datetime = "0.5.0"
 jetbrains-kotlinx-serialization = "1.6.3"
 
-koin-core = "3.5.3"
-koin-test = "3.5.3"
-koin-android = "3.5.3"
-koin-androidx-navigation = "3.5.3"
-koin-androidx-workManager = "3.5.3"
-koin-android-compose = "3.5.3"
+koin-core = "3.5.0"
+koin-test = "3.5.0"
+koin-android = "3.5.0"
+koin-androidx-navigation = "3.5.0"
+koin-androidx-workManager = "3.5.0"
+koin-android-compose = "3.5.0"
 
 markwon = "4.6.2"
 


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/anitrend-v2/blob/develop/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure you've done the following:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-v2/blob/develop/CONTRIBUTING.md)
- Double checked that your branch is based on `develop` and targets `develop` (where applicable)
- Pull request has tests (if applicable)
- Documentation is updated (if necessary)
- Description explains the issue/use-case resolved


## Description
<!--- Describe your changes in detail, or link an existing issue here -->
See: #552 

## Screenshots:
<!-- If applicable, otherwise feel free to remove this section -->
<video src="https://github.com/AniTrend/anitrend-v2/assets/7859175/0ae1a862-bdff-4e28-a9dc-77057c09765b" controls />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)

<!--- Be kind to code reviewers, and please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [GPL v3 License](https://github.com/AniTrend/anitrend-v2/blob/develop/LICENSE.md).
