### PR TITLE
refactor(data): standardize coordinated persistence through module writers (#1178)

### DIFF
--- a/data/android/src/main/kotlin/co/anitrend/data/android/mapper/EmbedMapper.kt
+++ b/data/android/src/main/kotlin/co/anitrend/data/android/mapper/EmbedMapper.kt
@@ -19,7 +19,7 @@ package co.anitrend.data.android.mapper
 import co.anitrend.arch.data.converter.SupportConverter
 import co.anitrend.data.android.source.local.AbstractLocalSource
 
-abstract class EmbedMapper<S, D> : DefaultMapper<List<S>, List<D>>() {
+abstract class EmbedMapper<S, D> : DefaultMapper<List<S>, List<D>>(), PersistEmbedded {
     protected var entities: List<D>? = null
     protected abstract val localSource: AbstractLocalSource<D>
     protected abstract val converter: SupportConverter<S, D>
@@ -34,7 +34,7 @@ abstract class EmbedMapper<S, D> : DefaultMapper<List<S>, List<D>>() {
         }
     }
 
-    open suspend fun persistEmbedded() {
+    override open suspend fun persistEmbedded() {
         onResponseDatabaseInsert(entities.orEmpty())
         entities = null
     }

--- a/data/android/src/main/kotlin/co/anitrend/data/android/mapper/PersistEmbedded.kt
+++ b/data/android/src/main/kotlin/co/anitrend/data/android/mapper/PersistEmbedded.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.android.mapper
+
+interface PersistEmbedded {
+    suspend fun persistEmbedded()
+}

--- a/data/src/main/kotlin/co/anitrend/data/airing/koin/Modules.kt
+++ b/data/src/main/kotlin/co/anitrend/data/airing/koin/Modules.kt
@@ -24,6 +24,8 @@ import co.anitrend.data.airing.converters.AiringEntityConverter
 import co.anitrend.data.airing.converters.AiringModelConverter
 import co.anitrend.data.airing.entity.filter.AiringQueryFilter
 import co.anitrend.data.airing.mapper.AiringMapper
+import co.anitrend.data.airing.mapper.AiringWriter
+import co.anitrend.data.airing.mapper.AiringWriterContract
 import co.anitrend.data.airing.repository.AiringScheduleRepository
 import co.anitrend.data.airing.source.AiringScheduleSourceImpl
 import co.anitrend.data.airing.source.contract.AiringScheduleSource
@@ -86,6 +88,12 @@ private val converterModule =
 
 private val mapperModule =
     module {
+        factory<AiringWriterContract> {
+            AiringWriter(
+                mediaPersistence = get<co.anitrend.data.media.mapper.MediaMapper.Embed>(),
+                localSource = store().airingScheduleDao(),
+            )
+        }
         factory {
             AiringMapper.Airing(
                 localSource = store().airingScheduleDao(),
@@ -95,6 +103,7 @@ private val mapperModule =
         factory {
             AiringMapper.Paged(
                 mediaMapper = get(),
+                writer = get(),
                 localSource = store().airingScheduleDao(),
                 converter = get(),
             )

--- a/data/src/main/kotlin/co/anitrend/data/airing/mapper/AiringMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/airing/mapper/AiringMapper.kt
@@ -31,6 +31,7 @@ internal sealed class AiringMapper<S, D> : DefaultMapper<S, D>() {
 
     class Paged(
         private val mediaMapper: MediaMapper.Embed,
+        private val writer: AiringWriterContract,
         override val localSource: AiringLocalSource,
         override val converter: AiringModelConverter,
     ) : AiringMapper<AiringScheduleModelContainer.Paged, List<AiringScheduleEntity>>() {
@@ -38,8 +39,7 @@ internal sealed class AiringMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<AiringScheduleEntity>) {
-            mediaMapper.persistEmbedded()
-            localSource.upsert(data)
+            writer.persist(data)
         }
 
         /**

--- a/data/src/main/kotlin/co/anitrend/data/airing/mapper/AiringWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/airing/mapper/AiringWriter.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.airing.mapper
+
+import co.anitrend.data.airing.datasource.local.AiringLocalSource
+import co.anitrend.data.airing.entity.AiringScheduleEntity
+import co.anitrend.data.android.mapper.PersistEmbedded
+
+internal fun interface AiringWriterContract {
+    suspend fun persist(entities: List<AiringScheduleEntity>)
+}
+
+internal class AiringWriter(
+    private val mediaPersistence: PersistEmbedded,
+    private val localSource: AiringLocalSource,
+) : AiringWriterContract {
+    override suspend fun persist(entities: List<AiringScheduleEntity>) {
+        mediaPersistence.persistEmbedded()
+        localSource.upsert(entities)
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/auth/koin/Modules.kt
+++ b/data/src/main/kotlin/co/anitrend/data/auth/koin/Modules.kt
@@ -18,7 +18,13 @@ package co.anitrend.data.auth.koin
 
 import co.anitrend.data.android.extensions.graphQLController
 import co.anitrend.data.auth.AuthUserInteractor
+import co.anitrend.data.auth.mapper.AuthenticatedUserWriter
+import co.anitrend.data.auth.mapper.AuthenticatedUserWriterContract
 import co.anitrend.data.auth.mapper.AuthMapper
+import co.anitrend.data.auth.mapper.UserGeneralOptionWriter
+import co.anitrend.data.auth.mapper.UserGeneralOptionWriterContract
+import co.anitrend.data.auth.mapper.UserMediaOptionWriter
+import co.anitrend.data.auth.mapper.UserMediaOptionWriterContract
 import co.anitrend.data.auth.repository.AuthRepositoryImpl
 import co.anitrend.data.auth.source.AuthSourceImpl
 import co.anitrend.data.auth.source.contract.AuthSource
@@ -52,13 +58,32 @@ private val mapperModule =
     module {
         factory {
             AuthMapper(
-                settings = get(),
                 generalOptionMapper = get(),
                 mediaOptionMapper = get(),
                 notificationMapper = get(),
-                localSource = store().userDao(),
+                writer = get(),
                 transactionRunner = transaction(),
                 converter = get(),
+            )
+        }
+        factory<AuthenticatedUserWriterContract> {
+            AuthenticatedUserWriter(
+                generalOptionWriter = get(),
+                mediaOptionWriter = get(),
+                notificationMapper = get(),
+                localSource = store().userDao(),
+            )
+        }
+        factory<UserGeneralOptionWriterContract> {
+            UserGeneralOptionWriter(
+                settings = get(),
+                mapper = get(),
+            )
+        }
+        factory<UserMediaOptionWriterContract> {
+            UserMediaOptionWriter(
+                settings = get(),
+                mapper = get(),
             )
         }
     }

--- a/data/src/main/kotlin/co/anitrend/data/auth/mapper/AuthMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/auth/mapper/AuthMapper.kt
@@ -26,11 +26,10 @@ import co.anitrend.data.user.model.container.UserModelContainer
 import co.anitrend.data.user.settings.IUserSettings
 
 internal class AuthMapper(
-    private val settings: IUserSettings,
     private val generalOptionMapper: UserMapper.GeneralOptionEmbed,
     private val mediaOptionMapper: UserMapper.MediaOptionEmbed,
     private val notificationMapper: UserMapper.NotificationEmbed,
-    private val localSource: UserLocalSource,
+    private val writer: AuthenticatedUserWriterContract,
     private val transactionRunner: TransactionRunner,
     private val converter: UserModelConverter,
 ) : DefaultMapper<UserModelContainer.Viewer, UserEntity>() {
@@ -38,10 +37,7 @@ internal class AuthMapper(
      * Save [data] into your desired local source
      */
     override suspend fun persist(data: UserEntity) {
-        localSource.upsert(data)
-        generalOptionMapper.persistEmbedded(settings)
-        mediaOptionMapper.persistEmbedded(settings)
-        notificationMapper.persistEmbedded()
+        writer.persist(data)
     }
 
     override suspend fun onResponseDatabaseInsert(mappedData: UserEntity) {

--- a/data/src/main/kotlin/co/anitrend/data/auth/mapper/AuthenticatedOptionWriters.kt
+++ b/data/src/main/kotlin/co/anitrend/data/auth/mapper/AuthenticatedOptionWriters.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.auth.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.user.mapper.UserMapper
+import co.anitrend.data.user.settings.IUserSettings
+
+internal fun interface UserGeneralOptionWriterContract {
+    suspend fun persist()
+}
+
+internal fun interface UserMediaOptionWriterContract {
+    suspend fun persist()
+}
+
+internal typealias NotificationPersistence = PersistEmbedded
+
+internal class UserGeneralOptionWriter(
+    private val settings: IUserSettings,
+    private val mapper: UserMapper.GeneralOptionEmbed,
+) : UserGeneralOptionWriterContract {
+    override suspend fun persist() {
+        mapper.persistEmbedded(settings)
+    }
+}
+
+internal class UserMediaOptionWriter(
+    private val settings: IUserSettings,
+    private val mapper: UserMapper.MediaOptionEmbed,
+) : UserMediaOptionWriterContract {
+    override suspend fun persist() {
+        mapper.persistEmbedded(settings)
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/auth/mapper/AuthenticatedUserWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/auth/mapper/AuthenticatedUserWriter.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.auth.mapper
+
+import co.anitrend.data.user.entity.UserEntity
+import co.anitrend.data.user.datasource.local.UserLocalSource
+
+internal fun interface AuthenticatedUserWriterContract {
+    suspend fun persist(user: UserEntity)
+}
+
+internal class AuthenticatedUserWriter(
+    private val generalOptionWriter: UserGeneralOptionWriterContract,
+    private val mediaOptionWriter: UserMediaOptionWriterContract,
+    private val notificationMapper: NotificationPersistence,
+    private val localSource: UserLocalSource,
+) : AuthenticatedUserWriterContract {
+    override suspend fun persist(user: UserEntity) {
+        localSource.upsert(user)
+        generalOptionWriter.persist()
+        mediaOptionWriter.persist()
+        notificationMapper.persistEmbedded()
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/media/koin/Modules.kt
+++ b/data/src/main/kotlin/co/anitrend/data/media/koin/Modules.kt
@@ -54,9 +54,21 @@ import co.anitrend.data.media.converter.MediaModelConverter
 import co.anitrend.data.media.converter.MediaStatsEntityConverter
 import co.anitrend.data.media.entity.filter.MediaQueryFilter
 import co.anitrend.data.media.mapper.MediaMapper
+import co.anitrend.data.media.mapper.MediaDetailWriter
+import co.anitrend.data.media.mapper.MediaDetailWriterContract
+import co.anitrend.data.media.mapper.MediaEmbedWithAiringWriter
+import co.anitrend.data.media.mapper.MediaEmbedWithAiringWriterContract
+import co.anitrend.data.media.mapper.MediaEmbedWithMediaListWriter
+import co.anitrend.data.media.mapper.MediaEmbedWithMediaListWriterContract
+import co.anitrend.data.media.mapper.MediaEmbedWriter
+import co.anitrend.data.media.mapper.MediaEmbedWriterContract
 import co.anitrend.data.media.mapper.MediaPeopleMapper
+import co.anitrend.data.media.mapper.MediaPagedWriter
+import co.anitrend.data.media.mapper.MediaPagedWriterContract
 import co.anitrend.data.media.mapper.MediaRelationMapper
 import co.anitrend.data.media.mapper.MediaStatsMapper
+import co.anitrend.data.media.mapper.MediaStatsWriter
+import co.anitrend.data.media.mapper.MediaStatsWriterContract
 import co.anitrend.data.media.repository.MediaRepository
 import co.anitrend.data.media.source.MediaConnectionSourceImpl
 import co.anitrend.data.media.source.MediaPeopleSourceImpl
@@ -312,11 +324,56 @@ private val converterModule =
 
 private val mapperModule =
     module {
+        factory<MediaPagedWriterContract> {
+            MediaPagedWriter(
+                localSource = store().mediaDao(),
+                tagPersistence = get<co.anitrend.data.tag.mapper.TagMapper.Embed>(),
+                genrePersistence = get<co.anitrend.data.genre.mapper.GenreMapper.Embed>(),
+                airingPersistence = get<co.anitrend.data.airing.mapper.AiringMapper.Embed>(),
+                mediaListPersistence = get<co.anitrend.data.medialist.mapper.MediaListMapper.Embed>(),
+            )
+        }
+        factory<MediaDetailWriterContract> {
+            MediaDetailWriter(
+                localSource = store().mediaDao(),
+                linkPersistence = get<co.anitrend.data.link.mapper.LinkMapper.Embed>(),
+                rankPersistence = get<co.anitrend.data.rank.mapper.RankMapper.Embed>(),
+                tagPersistence = get<co.anitrend.data.tag.mapper.TagMapper.Embed>(),
+                genrePersistence = get<co.anitrend.data.genre.mapper.GenreMapper.Embed>(),
+                airingPersistence = get<co.anitrend.data.airing.mapper.AiringMapper.Embed>(),
+                mediaListPersistence = get<co.anitrend.data.medialist.mapper.MediaListMapper.Embed>(),
+            )
+        }
+        factory<MediaEmbedWriterContract> {
+            MediaEmbedWriter(
+                localSource = store().mediaDao(),
+                tagPersistence = get<co.anitrend.data.tag.mapper.TagMapper.Embed>(),
+                genrePersistence = get<co.anitrend.data.genre.mapper.GenreMapper.Embed>(),
+            )
+        }
+        factory<MediaEmbedWithAiringWriterContract> {
+            MediaEmbedWithAiringWriter(
+                localSource = store().mediaDao(),
+                tagPersistence = get<co.anitrend.data.tag.mapper.TagMapper.Embed>(),
+                genrePersistence = get<co.anitrend.data.genre.mapper.GenreMapper.Embed>(),
+                airingPersistence = get<co.anitrend.data.airing.mapper.AiringMapper.Embed>(),
+            )
+        }
+        factory<MediaEmbedWithMediaListWriterContract> {
+            MediaEmbedWithMediaListWriter(
+                localSource = store().mediaDao(),
+                tagPersistence = get<co.anitrend.data.tag.mapper.TagMapper.Embed>(),
+                genrePersistence = get<co.anitrend.data.genre.mapper.GenreMapper.Embed>(),
+                airingPersistence = get<co.anitrend.data.airing.mapper.AiringMapper.Embed>(),
+                mediaListPersistence = get<co.anitrend.data.medialist.mapper.MediaListMapper.Embed>(),
+            )
+        }
         factory {
             MediaMapper.Detail(
                 mediaListMapper = get(),
                 genreMapper = get(),
                 tagMapper = get(),
+                writer = get(),
                 linkMapper = get(),
                 rankMapper = get(),
                 airingMapper = get(),
@@ -335,6 +392,7 @@ private val mapperModule =
                 mediaListMapper = get(),
                 genreMapper = get(),
                 tagMapper = get(),
+                writer = get(),
                 linkMapper = get(),
                 rankMapper = get(),
                 airingMapper = get(),
@@ -356,8 +414,13 @@ private val mapperModule =
         }
         factory {
             MediaStatsMapper(
-                localSource = store().mediaStatsDao(),
+                writer = get(),
                 transactionRunner = transaction(),
+            )
+        }
+        factory<MediaStatsWriterContract> {
+            MediaStatsWriter(
+                localSource = store().mediaStatsDao(),
             )
         }
         factory {
@@ -366,6 +429,7 @@ private val mapperModule =
                 tagMapper = get(),
                 linkMapper = get(),
                 rankMapper = get(),
+                writer = get(),
                 localSource = store().mediaDao(),
                 converter = get(),
             )
@@ -377,6 +441,7 @@ private val mapperModule =
                 tagMapper = get(),
                 linkMapper = get(),
                 rankMapper = get(),
+                writer = get(),
                 localSource = store().mediaDao(),
                 converter = get(),
             )
@@ -389,6 +454,7 @@ private val mapperModule =
                 tagMapper = get(),
                 linkMapper = get(),
                 rankMapper = get(),
+                writer = get(),
                 localSource = store().mediaDao(),
                 converter = get(),
             )

--- a/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaMapper.kt
@@ -43,6 +43,7 @@ internal sealed class MediaMapper<S, D> : DefaultMapper<S, D>() {
         private val airingMapper: AiringMapper.Embed,
         private val genreMapper: GenreMapper.Embed,
         private val tagMapper: TagMapper.Embed,
+        private val writer: MediaPagedWriterContract,
         override val linkMapper: LinkMapper.Embed,
         override val rankMapper: RankMapper.Embed,
         override val localSource: MediaLocalSource,
@@ -52,11 +53,7 @@ internal sealed class MediaMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<MediaEntity>) {
-            localSource.upsert(data)
-            tagMapper.persistEmbedded()
-            genreMapper.persistEmbedded()
-            airingMapper.persistEmbedded()
-            mediaListMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -97,19 +94,14 @@ internal sealed class MediaMapper<S, D> : DefaultMapper<S, D>() {
         private val airingMapper: AiringMapper.Embed,
         private val genreMapper: GenreMapper.Embed,
         private val tagMapper: TagMapper.Embed,
+        private val writer: MediaDetailWriterContract,
         override val linkMapper: LinkMapper.Embed,
         override val rankMapper: RankMapper.Embed,
         override val localSource: MediaLocalSource,
         override val converter: MediaModelConverter,
     ) : MediaMapper<MediaModelContainer.Detail, MediaEntity>() {
         override suspend fun persist(data: MediaEntity) {
-            localSource.upsert(data)
-            linkMapper.persistEmbedded()
-            rankMapper.persistEmbedded()
-            tagMapper.persistEmbedded()
-            genreMapper.persistEmbedded()
-            airingMapper.persistEmbedded()
-            mediaListMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -144,6 +136,7 @@ internal sealed class MediaMapper<S, D> : DefaultMapper<S, D>() {
         private val tagMapper: TagMapper.Embed,
         private val linkMapper: LinkMapper.Embed,
         private val rankMapper: RankMapper.Embed,
+        private val writer: MediaEmbedWriterContract,
         override val localSource: MediaLocalSource,
         override val converter: MediaModelConverter,
     ) : EmbedMapper<MediaModel, MediaEntity>() {
@@ -151,9 +144,7 @@ internal sealed class MediaMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<MediaEntity>) {
-            super.persist(data)
-            tagMapper.persistEmbedded()
-            genreMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -185,14 +176,12 @@ internal sealed class MediaMapper<S, D> : DefaultMapper<S, D>() {
         private val tagMapper: TagMapper.Embed,
         private val linkMapper: LinkMapper.Embed,
         private val rankMapper: RankMapper.Embed,
+        private val writer: MediaEmbedWithAiringWriterContract,
         override val localSource: MediaLocalSource,
         override val converter: MediaModelConverter,
     ) : EmbedMapper<MediaModel, MediaEntity>() {
         override suspend fun persist(data: List<MediaEntity>) {
-            super.persist(data)
-            tagMapper.persistEmbedded()
-            genreMapper.persistEmbedded()
-            airingMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -230,15 +219,12 @@ internal sealed class MediaMapper<S, D> : DefaultMapper<S, D>() {
         private val tagMapper: TagMapper.Embed,
         private val linkMapper: LinkMapper.Embed,
         private val rankMapper: RankMapper.Embed,
+        private val writer: MediaEmbedWithMediaListWriterContract,
         override val localSource: MediaLocalSource,
         override val converter: MediaModelConverter,
     ) : EmbedMapper<MediaModel, MediaEntity>() {
         override suspend fun persist(data: List<MediaEntity>) {
-            super.persist(data)
-            tagMapper.persistEmbedded()
-            genreMapper.persistEmbedded()
-            airingMapper.persistEmbedded()
-            mediaListMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**

--- a/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaStatsMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaStatsMapper.kt
@@ -25,7 +25,7 @@ import co.anitrend.data.media.entity.stats.MediaStatusDistributionEntity
 import co.anitrend.data.media.model.container.MediaSidecarModelContainer
 
 internal class MediaStatsMapper(
-    private val localSource: MediaStatsLocalSource,
+    private val writer: MediaStatsWriterContract,
     private val transactionRunner: TransactionRunner,
 ) : DefaultMapper<MediaSidecarModelContainer.Stats, MediaStatsMapper.Payload?>() {
     internal data class Payload(
@@ -36,9 +36,7 @@ internal class MediaStatsMapper(
 
     override suspend fun persist(data: Payload?) {
         if (data != null) {
-            localSource.upsert(data.stats)
-            localSource.upsertScoreDistributions(data.scoreDistribution)
-            localSource.upsertStatusDistributions(data.statusDistribution)
+            writer.persist(data)
         }
     }
 

--- a/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaStatsWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaStatsWriter.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.media.mapper
+
+import co.anitrend.data.media.datasource.local.MediaStatsLocalSource
+
+internal fun interface MediaStatsWriterContract {
+    suspend fun persist(payload: MediaStatsMapper.Payload)
+}
+
+internal class MediaStatsWriter(
+    private val localSource: MediaStatsLocalSource,
+) : MediaStatsWriterContract {
+    override suspend fun persist(payload: MediaStatsMapper.Payload) {
+        localSource.upsert(payload.stats)
+        localSource.upsertScoreDistributions(payload.scoreDistribution)
+        localSource.upsertStatusDistributions(payload.statusDistribution)
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaWriters.kt
+++ b/data/src/main/kotlin/co/anitrend/data/media/mapper/MediaWriters.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.media.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.media.datasource.local.MediaLocalSource
+import co.anitrend.data.media.entity.MediaEntity
+
+internal fun interface MediaPagedWriterContract {
+    suspend fun persist(entities: List<MediaEntity>)
+}
+
+internal fun interface MediaDetailWriterContract {
+    suspend fun persist(entity: MediaEntity)
+}
+
+internal fun interface MediaEmbedWriterContract {
+    suspend fun persist(entities: List<MediaEntity>)
+}
+
+internal fun interface MediaEmbedWithAiringWriterContract {
+    suspend fun persist(entities: List<MediaEntity>)
+}
+
+internal fun interface MediaEmbedWithMediaListWriterContract {
+    suspend fun persist(entities: List<MediaEntity>)
+}
+
+internal class MediaPagedWriter(
+    private val localSource: MediaLocalSource,
+    private val tagPersistence: PersistEmbedded,
+    private val genrePersistence: PersistEmbedded,
+    private val airingPersistence: PersistEmbedded,
+    private val mediaListPersistence: PersistEmbedded,
+) : MediaPagedWriterContract {
+    override suspend fun persist(entities: List<MediaEntity>) {
+        localSource.upsert(entities)
+        tagPersistence.persistEmbedded()
+        genrePersistence.persistEmbedded()
+        airingPersistence.persistEmbedded()
+        mediaListPersistence.persistEmbedded()
+    }
+}
+
+internal class MediaDetailWriter(
+    private val localSource: MediaLocalSource,
+    private val linkPersistence: PersistEmbedded,
+    private val rankPersistence: PersistEmbedded,
+    private val tagPersistence: PersistEmbedded,
+    private val genrePersistence: PersistEmbedded,
+    private val airingPersistence: PersistEmbedded,
+    private val mediaListPersistence: PersistEmbedded,
+) : MediaDetailWriterContract {
+    override suspend fun persist(entity: MediaEntity) {
+        localSource.upsert(entity)
+        linkPersistence.persistEmbedded()
+        rankPersistence.persistEmbedded()
+        tagPersistence.persistEmbedded()
+        genrePersistence.persistEmbedded()
+        airingPersistence.persistEmbedded()
+        mediaListPersistence.persistEmbedded()
+    }
+}
+
+internal class MediaEmbedWriter(
+    private val localSource: MediaLocalSource,
+    private val tagPersistence: PersistEmbedded,
+    private val genrePersistence: PersistEmbedded,
+) : MediaEmbedWriterContract {
+    override suspend fun persist(entities: List<MediaEntity>) {
+        localSource.upsert(entities)
+        tagPersistence.persistEmbedded()
+        genrePersistence.persistEmbedded()
+    }
+}
+
+internal class MediaEmbedWithAiringWriter(
+    private val localSource: MediaLocalSource,
+    private val tagPersistence: PersistEmbedded,
+    private val genrePersistence: PersistEmbedded,
+    private val airingPersistence: PersistEmbedded,
+) : MediaEmbedWithAiringWriterContract {
+    override suspend fun persist(entities: List<MediaEntity>) {
+        localSource.upsert(entities)
+        tagPersistence.persistEmbedded()
+        genrePersistence.persistEmbedded()
+        airingPersistence.persistEmbedded()
+    }
+}
+
+internal class MediaEmbedWithMediaListWriter(
+    private val localSource: MediaLocalSource,
+    private val tagPersistence: PersistEmbedded,
+    private val genrePersistence: PersistEmbedded,
+    private val airingPersistence: PersistEmbedded,
+    private val mediaListPersistence: PersistEmbedded,
+) : MediaEmbedWithMediaListWriterContract {
+    override suspend fun persist(entities: List<MediaEntity>) {
+        localSource.upsert(entities)
+        tagPersistence.persistEmbedded()
+        genrePersistence.persistEmbedded()
+        airingPersistence.persistEmbedded()
+        mediaListPersistence.persistEmbedded()
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/medialist/koin/Modules.kt
+++ b/data/src/main/kotlin/co/anitrend/data/medialist/koin/Modules.kt
@@ -40,6 +40,12 @@ import co.anitrend.data.medialist.converter.MediaListEntityViewConverter
 import co.anitrend.data.medialist.converter.MediaListModelConverter
 import co.anitrend.data.medialist.entity.filter.MediaListQueryFilter
 import co.anitrend.data.medialist.mapper.MediaListMapper
+import co.anitrend.data.medialist.mapper.MediaListEmbedWithMediaWriter
+import co.anitrend.data.medialist.mapper.MediaListEmbedWithMediaWriterContract
+import co.anitrend.data.medialist.mapper.MediaListEmbedWriter
+import co.anitrend.data.medialist.mapper.MediaListEmbedWriterContract
+import co.anitrend.data.medialist.mapper.MediaListWriter
+import co.anitrend.data.medialist.mapper.MediaListWriterContract
 import co.anitrend.data.medialist.repository.MediaListRepository
 import co.anitrend.data.medialist.source.MediaListSourceImpl
 import co.anitrend.data.medialist.source.contract.MediaListSource
@@ -154,6 +160,30 @@ private val cacheModule =
 
 private val mapperModule =
     module {
+        factory<MediaListWriterContract> {
+            MediaListWriter(
+                userPersistence = get<co.anitrend.data.user.mapper.UserMapper.Embed>(),
+                mediaPersistence = get<co.anitrend.data.media.mapper.MediaMapper.EmbedWithAiring>(),
+                localSource = store().mediaListDao(),
+                customListPersistence = get<co.anitrend.data.customlist.mapper.CustomListMapper>(),
+                customScorePersistence = get<co.anitrend.data.customscore.mapper.CustomScoreMapper>(),
+            )
+        }
+        factory<MediaListEmbedWriterContract> {
+            MediaListEmbedWriter(
+                userPersistence = get<co.anitrend.data.user.mapper.UserMapper.Embed>(),
+                localSource = store().mediaListDao(),
+                customListPersistence = get<co.anitrend.data.customlist.mapper.CustomListMapper>(),
+                customScorePersistence = get<co.anitrend.data.customscore.mapper.CustomScoreMapper>(),
+            )
+        }
+        factory<MediaListEmbedWithMediaWriterContract> {
+            MediaListEmbedWithMediaWriter(
+                userPersistence = get<co.anitrend.data.user.mapper.UserMapper.Embed>(),
+                mediaPersistence = get<co.anitrend.data.media.mapper.MediaMapper.EmbedWithAiring>(),
+                localSource = store().mediaListDao(),
+            )
+        }
         factory {
             MediaListMapper.DeletedEntry(
                 localSource = store().mediaListDao(),
@@ -172,6 +202,7 @@ private val mapperModule =
                 mediaMapper = get(),
                 customListMapper = get(),
                 customScoreMapper = get(),
+                writer = get(),
                 localSource = store().mediaListDao(),
                 converter = get(),
             )
@@ -182,6 +213,7 @@ private val mapperModule =
                 mediaMapper = get(),
                 customListMapper = get(),
                 customScoreMapper = get(),
+                writer = get(),
                 localSource = store().mediaListDao(),
                 converter = get(),
             )
@@ -192,6 +224,7 @@ private val mapperModule =
                 mediaMapper = get(),
                 customListMapper = get(),
                 customScoreMapper = get(),
+                writer = get(),
                 localSource = store().mediaListDao(),
                 converter = get(),
             )
@@ -202,6 +235,7 @@ private val mapperModule =
                 mediaMapper = get(),
                 customListMapper = get(),
                 customScoreMapper = get(),
+                writer = get(),
                 localSource = store().mediaListDao(),
                 converter = get(),
             )
@@ -212,6 +246,7 @@ private val mapperModule =
                 mediaMapper = get(),
                 customListMapper = get(),
                 customScoreMapper = get(),
+                writer = get(),
                 localSource = store().mediaListDao(),
                 converter = get(),
             )
@@ -221,6 +256,7 @@ private val mapperModule =
                 userMapper = get(),
                 customListMapper = get(),
                 customScoreMapper = get(),
+                writer = get(),
                 localSource = store().mediaListDao(),
                 converter = get(),
             )
@@ -229,6 +265,7 @@ private val mapperModule =
             MediaListMapper.EmbedWithMedia(
                 userMapper = get(),
                 mediaMapper = get(),
+                writer = get(),
                 localSource = store().mediaListDao(),
                 converter = get(),
             )

--- a/data/src/main/kotlin/co/anitrend/data/medialist/mapper/MediaListMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/medialist/mapper/MediaListMapper.kt
@@ -76,6 +76,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
         private val mediaMapper: MediaMapper.EmbedWithAiring,
         private val customListMapper: CustomListMapper,
         private val customScoreMapper: CustomScoreMapper,
+        private val writer: MediaListWriterContract,
         override val localSource: MediaListLocalSource,
         override val converter: MediaListModelConverter,
     ) : MediaListMapper<MediaListContainerModel.Entry, MediaListEntity>() {
@@ -83,11 +84,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: MediaListEntity) {
-            userMapper.persistEmbedded()
-            mediaMapper.persistEmbedded()
-            localSource.upsert(data)
-            customListMapper.persistEmbedded()
-            customScoreMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -118,6 +115,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
         private val mediaMapper: MediaMapper.EmbedWithAiring,
         private val customListMapper: CustomListMapper,
         private val customScoreMapper: CustomScoreMapper,
+        private val writer: MediaListWriterContract,
         override val localSource: MediaListLocalSource,
         override val converter: MediaListModelConverter,
     ) : MediaListMapper<MediaListContainerModel.SavedEntry, MediaListEntity>() {
@@ -125,11 +123,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: MediaListEntity) {
-            userMapper.persistEmbedded()
-            mediaMapper.persistEmbedded()
-            localSource.upsert(data)
-            customListMapper.persistEmbedded()
-            customScoreMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -157,6 +151,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
         private val mediaMapper: MediaMapper.EmbedWithAiring,
         private val customListMapper: CustomListMapper,
         private val customScoreMapper: CustomScoreMapper,
+        private val writer: MediaListWriterContract,
         override val localSource: MediaListLocalSource,
         override val converter: MediaListModelConverter,
     ) : MediaListMapper<MediaListContainerModel.SavedEntries, List<MediaListEntity>>() {
@@ -164,11 +159,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<MediaListEntity>) {
-            userMapper.persistEmbedded()
-            mediaMapper.persistEmbedded()
-            localSource.upsert(data)
-            customListMapper.persistEmbedded()
-            customScoreMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -196,6 +187,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
         private val customListMapper: CustomListMapper,
         private val customScoreMapper: CustomScoreMapper,
         private val userMapper: UserMapper.Embed,
+        private val writer: MediaListWriterContract,
         override val localSource: MediaListLocalSource,
         override val converter: MediaListModelConverter,
     ) : MediaListMapper<MediaListContainerModel.Collection, List<MediaListEntity>>() {
@@ -203,11 +195,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<MediaListEntity>) {
-            userMapper.persistEmbedded()
-            mediaMapper.persistEmbedded()
-            localSource.upsert(data)
-            customListMapper.persistEmbedded()
-            customScoreMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -237,6 +225,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
         private val customListMapper: CustomListMapper,
         private val customScoreMapper: CustomScoreMapper,
         private val mediaMapper: MediaMapper.EmbedWithAiring,
+        private val writer: MediaListWriterContract,
         override val localSource: MediaListLocalSource,
         override val converter: MediaListModelConverter,
     ) : MediaListMapper<MediaListContainerModel.Paged, List<MediaListEntity>>() {
@@ -244,11 +233,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<MediaListEntity>) {
-            userMapper.persistEmbedded()
-            mediaMapper.persistEmbedded()
-            localSource.upsert(data)
-            customListMapper.persistEmbedded()
-            customScoreMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -282,6 +267,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
         private val userMapper: UserMapper.Embed,
         private val customListMapper: CustomListMapper,
         private val customScoreMapper: CustomScoreMapper,
+        private val writer: MediaListEmbedWriterContract,
         override val localSource: MediaListLocalSource,
         override val converter: MediaListModelConverter,
     ) : EmbedMapper<MediaListModel, MediaListEntity>() {
@@ -289,10 +275,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<MediaListEntity>) {
-            super.persist(data)
-            userMapper.persistEmbedded()
-            customListMapper.persistEmbedded()
-            customScoreMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         /**
@@ -318,6 +301,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
     class EmbedWithMedia(
         private val userMapper: UserMapper.Embed,
         private val mediaMapper: MediaMapper.EmbedWithAiring,
+        private val writer: MediaListEmbedWithMediaWriterContract,
         override val localSource: MediaListLocalSource,
         override val converter: MediaListModelConverter,
     ) : EmbedMapper<MediaListModel, MediaListEntity>() {
@@ -325,9 +309,7 @@ internal sealed class MediaListMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<MediaListEntity>) {
-            userMapper.persistEmbedded()
-            mediaMapper.persistEmbedded()
-            super.persist(data)
+            writer.persist(data)
         }
 
         /**

--- a/data/src/main/kotlin/co/anitrend/data/medialist/mapper/MediaListWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/medialist/mapper/MediaListWriter.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.medialist.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.medialist.datasource.local.MediaListLocalSource
+import co.anitrend.data.medialist.entity.MediaListEntity
+
+internal interface MediaListWriterContract {
+    suspend fun persist(entity: MediaListEntity)
+
+    suspend fun persist(entities: List<MediaListEntity>)
+}
+
+internal fun interface MediaListEmbedWriterContract {
+    suspend fun persist(entities: List<MediaListEntity>)
+}
+
+internal fun interface MediaListEmbedWithMediaWriterContract {
+    suspend fun persist(entities: List<MediaListEntity>)
+}
+
+internal class MediaListWriter(
+    private val userPersistence: PersistEmbedded,
+    private val mediaPersistence: PersistEmbedded,
+    private val localSource: MediaListLocalSource,
+    private val customListPersistence: PersistEmbedded,
+    private val customScorePersistence: PersistEmbedded,
+) : MediaListWriterContract {
+    override suspend fun persist(entity: MediaListEntity) {
+        userPersistence.persistEmbedded()
+        mediaPersistence.persistEmbedded()
+        localSource.upsert(entity)
+        customListPersistence.persistEmbedded()
+        customScorePersistence.persistEmbedded()
+    }
+
+    override suspend fun persist(entities: List<MediaListEntity>) {
+        userPersistence.persistEmbedded()
+        mediaPersistence.persistEmbedded()
+        localSource.upsert(entities)
+        customListPersistence.persistEmbedded()
+        customScorePersistence.persistEmbedded()
+    }
+}
+
+internal class MediaListEmbedWriter(
+    private val userPersistence: PersistEmbedded,
+    private val localSource: MediaListLocalSource,
+    private val customListPersistence: PersistEmbedded,
+    private val customScorePersistence: PersistEmbedded,
+) : MediaListEmbedWriterContract {
+    override suspend fun persist(entities: List<MediaListEntity>) {
+        localSource.upsert(entities)
+        userPersistence.persistEmbedded()
+        customListPersistence.persistEmbedded()
+        customScorePersistence.persistEmbedded()
+    }
+}
+
+internal class MediaListEmbedWithMediaWriter(
+    private val userPersistence: PersistEmbedded,
+    private val mediaPersistence: PersistEmbedded,
+    private val localSource: MediaListLocalSource,
+) : MediaListEmbedWithMediaWriterContract {
+    override suspend fun persist(entities: List<MediaListEntity>) {
+        userPersistence.persistEmbedded()
+        mediaPersistence.persistEmbedded()
+        localSource.upsert(entities)
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/review/koin/Modules.kt
+++ b/data/src/main/kotlin/co/anitrend/data/review/koin/Modules.kt
@@ -37,6 +37,8 @@ import co.anitrend.data.review.converter.ReviewEntityViewConverter
 import co.anitrend.data.review.converter.ReviewModelConverter
 import co.anitrend.data.review.entity.filter.ReviewQueryFilter
 import co.anitrend.data.review.mapper.ReviewMapper
+import co.anitrend.data.review.mapper.ReviewWriter
+import co.anitrend.data.review.mapper.ReviewWriterContract
 import co.anitrend.data.review.repository.ReviewRepository
 import co.anitrend.data.review.source.ReviewSourceImpl
 import co.anitrend.data.review.source.contract.ReviewSource
@@ -121,9 +123,17 @@ private val cacheModule =
 
 private val mapperModule =
     module {
+        factory<ReviewWriterContract> {
+            ReviewWriter(
+                mediaPersistence = get<co.anitrend.data.media.mapper.MediaMapper.EmbedWithAiring>(),
+                userPersistence = get<co.anitrend.data.user.mapper.UserMapper.Embed>(),
+                localSource = store().reviewDao(),
+            )
+        }
         factory {
             ReviewMapper.Entry(
                 mediaMapper = get(),
+                writer = get(),
                 localSource = store().reviewDao(),
                 converter = get(),
             )
@@ -150,6 +160,7 @@ private val mapperModule =
             ReviewMapper.Paged(
                 mediaMapper = get(),
                 userMapper = get(),
+                writer = get(),
                 localSource = store().reviewDao(),
                 converter = get(),
             )

--- a/data/src/main/kotlin/co/anitrend/data/review/mapper/ReviewMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/review/mapper/ReviewMapper.kt
@@ -36,6 +36,7 @@ internal sealed class ReviewMapper<S, D> : DefaultMapper<S, D>() {
 
     class Entry(
         private val mediaMapper: MediaMapper.EmbedWithAiring,
+        private val writer: ReviewWriterContract,
         override val localSource: ReviewLocalSource,
         override val converter: ReviewModelConverter,
     ) : ReviewMapper<ReviewContainerModel.Entry, ReviewEntity>() {
@@ -56,14 +57,14 @@ internal sealed class ReviewMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: ReviewEntity) {
-            mediaMapper.persistEmbedded()
-            localSource.upsert(data)
+            writer.persist(data)
         }
     }
 
     class Paged(
         private val mediaMapper: MediaMapper.EmbedWithAiring,
         private val userMapper: UserMapper.Embed,
+        private val writer: ReviewWriterContract,
         override val localSource: ReviewLocalSource,
         override val converter: ReviewModelConverter,
     ) : ReviewMapper<ReviewContainerModel.Paged, List<ReviewEntity>>() {
@@ -91,9 +92,7 @@ internal sealed class ReviewMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: List<ReviewEntity>) {
-            mediaMapper.persistEmbedded()
-            userMapper.persistEmbedded()
-            localSource.upsert(data)
+            writer.persist(data)
         }
     }
 

--- a/data/src/main/kotlin/co/anitrend/data/review/mapper/ReviewWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/review/mapper/ReviewWriter.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.review.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.review.datasource.local.ReviewLocalSource
+import co.anitrend.data.review.entity.ReviewEntity
+
+internal interface ReviewWriterContract {
+    suspend fun persist(entity: ReviewEntity)
+
+    suspend fun persist(entities: List<ReviewEntity>)
+}
+
+internal class ReviewWriter(
+    private val mediaPersistence: PersistEmbedded,
+    private val userPersistence: PersistEmbedded,
+    private val localSource: ReviewLocalSource,
+) : ReviewWriterContract {
+    override suspend fun persist(entity: ReviewEntity) {
+        mediaPersistence.persistEmbedded()
+        localSource.upsert(entity)
+    }
+
+    override suspend fun persist(entities: List<ReviewEntity>) {
+        mediaPersistence.persistEmbedded()
+        userPersistence.persistEmbedded()
+        localSource.upsert(entities)
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/user/koin/Modules.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/koin/Modules.kt
@@ -19,6 +19,7 @@ package co.anitrend.data.user.koin
 import co.anitrend.data.android.extensions.cacheLocalSource
 import co.anitrend.data.android.extensions.graphQLController
 import co.anitrend.data.android.extensions.offline
+import co.anitrend.data.android.mapper.EmbedMapper
 import co.anitrend.data.auth.mapper.AuthMapper
 import co.anitrend.data.core.extensions.aniListApi
 import co.anitrend.data.core.extensions.store
@@ -52,7 +53,17 @@ import co.anitrend.data.user.converter.UserStatisticModelConverter
 import co.anitrend.data.user.converter.UserViewEntityConverter
 import co.anitrend.data.user.mapper.UserMapper
 import co.anitrend.data.user.mapper.UserProfileFeedMapper
+import co.anitrend.data.user.mapper.UserProfileWriter
+import co.anitrend.data.user.mapper.UserProfileWriterContract
 import co.anitrend.data.user.mapper.UserProfileOverviewMapper
+import co.anitrend.data.user.mapper.UserProfileFeedWriter
+import co.anitrend.data.user.mapper.UserProfileFeedWriterContract
+import co.anitrend.data.user.mapper.UserProfileOverviewWriter
+import co.anitrend.data.user.mapper.UserProfileOverviewWriterContract
+import co.anitrend.data.user.mapper.UserStatisticPersistenceWriter
+import co.anitrend.data.user.mapper.UserStatisticPersistenceWriterContract
+import co.anitrend.data.user.mapper.UserStatisticWriter
+import co.anitrend.data.user.mapper.UserStatisticWriterContract
 import co.anitrend.data.user.repository.UserRepository
 import co.anitrend.data.user.source.UserSourceImpl
 import co.anitrend.data.user.source.contract.UserSource
@@ -244,9 +255,18 @@ private val mapperModule =
                 generalOptionMapper = get(),
                 mediaOptionMapper = get(),
                 previousNameMapper = get(),
+                writer = get(),
                 localSource = store().userDao(),
                 transactionRunner = transaction(),
                 converter = get(),
+            )
+        }
+        factory<UserProfileWriterContract> {
+            UserProfileWriter(
+                localSource = store().userDao(),
+                generalOptionMapper = get(),
+                mediaOptionMapper = get(),
+                previousNameMapper = get(),
             )
         }
         factory {
@@ -291,9 +311,35 @@ private val mapperModule =
         factory {
             UserMapper.Statistic(
                 userMapper = get(),
-                localSource = store().userStatisticDao(),
+                writer = get(),
                 converter = get(),
                 transactionRunner = transaction(),
+            )
+        }
+        factory<UserStatisticPersistenceWriterContract> {
+            UserStatisticPersistenceWriter(
+                userPersistence = get<UserMapper.Embed>(),
+                statisticWriter = get(),
+            )
+        }
+        factory<UserStatisticWriterContract> {
+            UserStatisticWriter(
+                localSource = store().userStatisticDao(),
+            )
+        }
+        factory<UserProfileOverviewWriterContract> {
+            UserProfileOverviewWriter(
+                mediaPersistence = get<EmbedMapper<co.anitrend.data.media.model.MediaModel, co.anitrend.data.media.entity.MediaEntity>>(),
+                favouritePersistence = get<UserProfileConnectionMapper.FavouriteEmbed>(),
+                statusPersistence = get<StatusMapper.Activity.Embed>(),
+            )
+        }
+        factory<UserProfileFeedWriterContract> {
+            UserProfileFeedWriter(
+                mediaPersistence = get<EmbedMapper<co.anitrend.data.media.model.MediaModel, co.anitrend.data.media.entity.MediaEntity>>(),
+                reviewPreviewPersistence = get<ReviewMapper.PreviewEmbed>(),
+                reviewConnectionPersistence = get<UserProfileConnectionMapper.ReviewEmbed>(),
+                statusPersistence = get<StatusMapper.Activity.Embed>(),
             )
         }
         factory {
@@ -301,6 +347,7 @@ private val mapperModule =
                 favouriteEmbedMapper = get(),
                 statusEmbedMapper = get(),
                 mediaEmbedMapper = get(),
+                writer = get(),
                 transactionRunner = transaction(),
             )
         }
@@ -310,6 +357,7 @@ private val mapperModule =
                 reviewPreviewMapper = get(),
                 statusEmbedMapper = get(),
                 mediaEmbedMapper = get(),
+                writer = get(),
                 transactionRunner = transaction(),
             )
         }

--- a/data/src/main/kotlin/co/anitrend/data/user/mapper/UserMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/mapper/UserMapper.kt
@@ -69,6 +69,7 @@ internal sealed class UserMapper<S, D> : DefaultMapper<S, D>() {
         private val generalOptionMapper: GeneralOptionEmbed,
         private val mediaOptionMapper: MediaOptionEmbed,
         private val previousNameMapper: PreviousNameEmbed,
+        private val writer: UserProfileWriterContract,
         override val localSource: UserLocalSource,
         private val transactionRunner: TransactionRunner,
         override val converter: UserModelConverter,
@@ -77,10 +78,7 @@ internal sealed class UserMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: UserEntity) {
-            localSource.upsert(data)
-            generalOptionMapper.persistEmbedded()
-            mediaOptionMapper.persistEmbedded()
-            previousNameMapper.persistEmbedded()
+            writer.persist(data)
         }
 
         override suspend fun onResponseDatabaseInsert(mappedData: UserEntity) {
@@ -107,7 +105,7 @@ internal sealed class UserMapper<S, D> : DefaultMapper<S, D>() {
 
     class Statistic(
         private val userMapper: Embed,
-        private val localSource: UserStatisticLocalSource,
+        private val writer: UserStatisticPersistenceWriterContract,
         private val converter: UserStatisticModelConverter,
         private val transactionRunner: TransactionRunner,
     ) : DefaultMapper<UserModelContainer.WithStatistic, UserStatisticPayload>() {
@@ -115,20 +113,7 @@ internal sealed class UserMapper<S, D> : DefaultMapper<S, D>() {
          * Save [data] into your desired local source
          */
         override suspend fun persist(data: UserStatisticPayload) {
-            userMapper.persistEmbedded()
-            localSource.upsert(data.statistic)
-            localSource.upsertCountries(data.countries)
-            localSource.upsertFormats(data.formats)
-            localSource.upsertGenres(data.genres)
-            localSource.upsertLengths(data.lengths)
-            localSource.upsertReleaseYears(data.releaseYears)
-            localSource.upsertScores(data.scores)
-            localSource.upsertStaff(data.staff)
-            localSource.upsertStartYears(data.startYears)
-            localSource.upsertStatuses(data.statuses)
-            localSource.upsertStudios(data.studios)
-            localSource.upsertTags(data.tags)
-            localSource.upsertVoiceActors(data.voiceActors)
+            writer.persist(data)
         }
 
         override suspend fun onResponseDatabaseInsert(mappedData: UserStatisticPayload) {

--- a/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileFeedMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileFeedMapper.kt
@@ -30,13 +30,11 @@ internal class UserProfileFeedMapper(
     private val reviewPreviewMapper: ReviewMapper.PreviewEmbed,
     private val statusEmbedMapper: StatusMapper.Activity.Embed,
     private val mediaEmbedMapper: EmbedMapper<MediaModel, MediaEntity>,
+    private val writer: UserProfileFeedWriterContract,
     private val transactionRunner: TransactionRunner,
 ) : DefaultMapper<UserSidecarModelContainer.Feed, Unit>() {
     override suspend fun persist(data: Unit) {
-        mediaEmbedMapper.persistEmbedded()
-        reviewPreviewMapper.persistEmbedded()
-        reviewConnectionMapper.persistEmbedded()
-        statusEmbedMapper.persistEmbedded()
+        writer.persist()
     }
 
     override suspend fun onResponseDatabaseInsert(mappedData: Unit) {

--- a/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileOverviewMapper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileOverviewMapper.kt
@@ -29,12 +29,11 @@ internal class UserProfileOverviewMapper(
     private val favouriteEmbedMapper: UserProfileConnectionMapper.FavouriteEmbed,
     private val statusEmbedMapper: StatusMapper.Activity.Embed,
     private val mediaEmbedMapper: EmbedMapper<MediaModel, MediaEntity>,
+    private val writer: UserProfileOverviewWriterContract,
     private val transactionRunner: TransactionRunner,
 ) : DefaultMapper<UserSidecarModelContainer.Overview, Unit>() {
     override suspend fun persist(data: Unit) {
-        mediaEmbedMapper.persistEmbedded()
-        favouriteEmbedMapper.persistEmbedded()
-        statusEmbedMapper.persistEmbedded()
+        writer.persist()
     }
 
     override suspend fun onResponseDatabaseInsert(mappedData: Unit) {

--- a/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileWriter.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.user.mapper
+
+import co.anitrend.data.user.datasource.local.UserLocalSource
+import co.anitrend.data.user.entity.UserEntity
+
+internal fun interface UserProfileWriterContract {
+    suspend fun persist(user: UserEntity)
+}
+
+internal class UserProfileWriter(
+    private val localSource: UserLocalSource,
+    private val generalOptionMapper: UserMapper.GeneralOptionEmbed,
+    private val mediaOptionMapper: UserMapper.MediaOptionEmbed,
+    private val previousNameMapper: UserMapper.PreviousNameEmbed,
+) : UserProfileWriterContract {
+    override suspend fun persist(user: UserEntity) {
+        localSource.upsert(user)
+        generalOptionMapper.persistEmbedded()
+        mediaOptionMapper.persistEmbedded()
+        previousNameMapper.persistEmbedded()
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileWriters.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/mapper/UserProfileWriters.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.user.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+
+internal fun interface UserProfileOverviewWriterContract {
+    suspend fun persist()
+}
+
+internal fun interface UserProfileFeedWriterContract {
+    suspend fun persist()
+}
+
+internal class UserProfileOverviewWriter(
+    private val mediaPersistence: PersistEmbedded,
+    private val favouritePersistence: PersistEmbedded,
+    private val statusPersistence: PersistEmbedded,
+) : UserProfileOverviewWriterContract {
+    override suspend fun persist() {
+        mediaPersistence.persistEmbedded()
+        favouritePersistence.persistEmbedded()
+        statusPersistence.persistEmbedded()
+    }
+}
+
+internal class UserProfileFeedWriter(
+    private val mediaPersistence: PersistEmbedded,
+    private val reviewPreviewPersistence: PersistEmbedded,
+    private val reviewConnectionPersistence: PersistEmbedded,
+    private val statusPersistence: PersistEmbedded,
+) : UserProfileFeedWriterContract {
+    override suspend fun persist() {
+        mediaPersistence.persistEmbedded()
+        reviewPreviewPersistence.persistEmbedded()
+        reviewConnectionPersistence.persistEmbedded()
+        statusPersistence.persistEmbedded()
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/user/mapper/UserStatisticPersistenceWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/mapper/UserStatisticPersistenceWriter.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.user.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.user.converter.UserStatisticPayload
+
+internal fun interface UserStatisticPersistenceWriterContract {
+    suspend fun persist(payload: UserStatisticPayload)
+}
+
+internal class UserStatisticPersistenceWriter(
+    private val userPersistence: PersistEmbedded,
+    private val statisticWriter: UserStatisticWriterContract,
+) : UserStatisticPersistenceWriterContract {
+    override suspend fun persist(payload: UserStatisticPayload) {
+        userPersistence.persistEmbedded()
+        statisticWriter.persist(payload)
+    }
+}

--- a/data/src/main/kotlin/co/anitrend/data/user/mapper/UserStatisticWriter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/mapper/UserStatisticWriter.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.user.mapper
+
+import co.anitrend.data.user.converter.UserStatisticPayload
+import co.anitrend.data.user.datasource.local.statistic.UserStatisticLocalSource
+
+internal fun interface UserStatisticWriterContract {
+    suspend fun persist(payload: UserStatisticPayload)
+}
+
+internal class UserStatisticWriter(
+    private val localSource: UserStatisticLocalSource,
+) : UserStatisticWriterContract {
+    override suspend fun persist(payload: UserStatisticPayload) {
+        localSource.upsert(payload.statistic)
+        localSource.upsertCountries(payload.countries)
+        localSource.upsertFormats(payload.formats)
+        localSource.upsertGenres(payload.genres)
+        localSource.upsertLengths(payload.lengths)
+        localSource.upsertReleaseYears(payload.releaseYears)
+        localSource.upsertScores(payload.scores)
+        localSource.upsertStaff(payload.staff)
+        localSource.upsertStartYears(payload.startYears)
+        localSource.upsertStatuses(payload.statuses)
+        localSource.upsertStudios(payload.studios)
+        localSource.upsertTags(payload.tags)
+        localSource.upsertVoiceActors(payload.voiceActors)
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/airing/mapper/AiringWriterTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/airing/mapper/AiringWriterTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.airing.mapper
+
+import co.anitrend.data.airing.datasource.local.AiringLocalSource
+import co.anitrend.data.airing.entity.AiringScheduleEntity
+import co.anitrend.data.android.mapper.PersistEmbedded
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AiringWriterTest {
+    private fun airingEntity(id: Long) =
+        AiringScheduleEntity(
+            airingAt = 100L,
+            episode = 1,
+            mediaId = id * 10,
+            timeUntilAiring = 50L,
+            id = id,
+        )
+
+    @Test
+    fun `given airing schedules when persisting then media is flushed before local upsert`() =
+        runBlocking {
+            val mediaPersistence = FakePersistEmbedded()
+            val localSource = FakeAiringLocalSource()
+            val writer = AiringWriter(mediaPersistence = mediaPersistence, localSource = localSource)
+
+            writer.persist(
+                listOf(
+                    airingEntity(id = 5L),
+                    airingEntity(id = 7L),
+                ),
+            )
+
+            assertEquals(listOf(5L, 7L), localSource.upsertedIds)
+            assertEquals(1, mediaPersistence.invocationCount)
+        }
+
+    private class FakePersistEmbedded : PersistEmbedded {
+        var invocationCount = 0
+
+        override suspend fun persistEmbedded() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeAiringLocalSource : AiringLocalSource() {
+        val upsertedIds = mutableListOf<Long>()
+
+        override suspend fun count(): Int = 0
+
+        override suspend fun clear() {
+        }
+
+        override suspend fun airingByMediaId(mediaId: Long): AiringScheduleEntity? = null
+
+        override fun airingByMediaIdFlow(mediaId: Long): Flow<AiringScheduleEntity> =
+            flowOf(
+                AiringScheduleEntity(
+                    airingAt = 0L,
+                    episode = 0,
+                    mediaId = mediaId,
+                    timeUntilAiring = 0L,
+                    id = 0L,
+                ),
+            )
+
+        override suspend fun insert(attribute: AiringScheduleEntity): Long = 0L
+
+        override suspend fun insert(attribute: List<AiringScheduleEntity>): List<Long> = emptyList()
+
+        override suspend fun update(attribute: AiringScheduleEntity) {
+        }
+
+        override suspend fun update(attribute: List<AiringScheduleEntity>) {
+        }
+
+        override suspend fun delete(attribute: AiringScheduleEntity) {
+        }
+
+        override suspend fun delete(attribute: List<AiringScheduleEntity>) {
+        }
+
+        override suspend fun upsert(attribute: AiringScheduleEntity) {
+        }
+
+        override suspend fun upsert(attribute: List<AiringScheduleEntity>) {
+            upsertedIds += attribute.map(AiringScheduleEntity::id)
+        }
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/auth/mapper/AuthMapperTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/auth/mapper/AuthMapperTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.auth.mapper
+
+import co.anitrend.data.android.database.common.TransactionRunner
+import co.anitrend.data.user.converter.UserGeneralOptionModelConverter
+import co.anitrend.data.user.converter.UserMediaOptionModelConverter
+import co.anitrend.data.user.converter.UserModelConverter
+import co.anitrend.data.user.datasource.local.notification.UserNotificationLocalSource
+import co.anitrend.data.user.datasource.local.option.UserGeneralOptionLocalSource
+import co.anitrend.data.user.datasource.local.option.UserMediaOptionLocalSource
+import co.anitrend.data.user.entity.UserEntity
+import co.anitrend.data.user.entity.notification.UserNotificationEntity
+import co.anitrend.data.user.entity.option.UserGeneralOptionEntity
+import co.anitrend.data.user.entity.option.UserMediaOptionEntity
+import co.anitrend.data.user.mapper.UserMapper
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthMapperTest {
+    @Test
+    fun `given auth mapper when persisting user then writer is invoked inside transaction`() =
+        runBlocking {
+            val transactionRunner = FakeTransactionRunner()
+            val writer = FakeAuthenticatedUserWriter()
+            val mapper =
+                AuthMapper(
+                    generalOptionMapper = UserMapper.GeneralOptionEmbed(localSource = FakeUserGeneralOptionLocalSource(), converter = UserGeneralOptionModelConverter()),
+                    mediaOptionMapper = UserMapper.MediaOptionEmbed(localSource = FakeUserMediaOptionLocalSource(), converter = UserMediaOptionModelConverter()),
+                    notificationMapper = UserMapper.NotificationEmbed(localSource = FakeUserNotificationLocalSource()),
+                    writer = writer,
+                    transactionRunner = transactionRunner,
+                    converter = UserModelConverter(),
+                )
+
+            val user =
+                UserEntity(
+                    about = UserEntity.About(name = "viewer", bio = null, siteUrl = "https://anilist.co/user/viewer", donatorTier = null, donatorBadge = null),
+                    status = UserEntity.Status(isFollowing = false, isFollower = false, isBlocked = false),
+                    coverImage = UserEntity.CoverImage(),
+                    updatedAt = null,
+                    createdAt = null,
+                    id = 1L,
+                )
+
+            mapper.onResponseDatabaseInsert(user)
+
+            assertEquals(1, transactionRunner.invocationCount)
+            assertEquals(listOf(1L), writer.persistedUserIds)
+        }
+
+    private class FakeTransactionRunner : TransactionRunner {
+        var invocationCount = 0
+
+        override suspend fun run(block: suspend () -> Unit) {
+            invocationCount += 1
+            block()
+        }
+    }
+
+    private class FakeAuthenticatedUserWriter : AuthenticatedUserWriterContract {
+        val persistedUserIds = mutableListOf<Long>()
+
+        override suspend fun persist(user: UserEntity) {
+            persistedUserIds += user.id
+        }
+    }
+
+    private class FakeUserGeneralOptionLocalSource : UserGeneralOptionLocalSource() {
+        override suspend fun count(): Int = 0
+        override suspend fun clear() {}
+        override suspend fun insert(attribute: UserGeneralOptionEntity): Long = 0L
+        override suspend fun insert(attribute: List<UserGeneralOptionEntity>): List<Long> = emptyList()
+        override suspend fun update(attribute: UserGeneralOptionEntity) {}
+        override suspend fun update(attribute: List<UserGeneralOptionEntity>) {}
+        override suspend fun delete(attribute: UserGeneralOptionEntity) {}
+        override suspend fun delete(attribute: List<UserGeneralOptionEntity>) {}
+        override suspend fun upsert(attribute: UserGeneralOptionEntity) {}
+        override suspend fun upsert(attribute: List<UserGeneralOptionEntity>) {}
+    }
+
+    private class FakeUserMediaOptionLocalSource : UserMediaOptionLocalSource() {
+        override suspend fun count(): Int = 0
+        override suspend fun clear() {}
+        override suspend fun insert(attribute: UserMediaOptionEntity): Long = 0L
+        override suspend fun insert(attribute: List<UserMediaOptionEntity>): List<Long> = emptyList()
+        override suspend fun update(attribute: UserMediaOptionEntity) {}
+        override suspend fun update(attribute: List<UserMediaOptionEntity>) {}
+        override suspend fun delete(attribute: UserMediaOptionEntity) {}
+        override suspend fun delete(attribute: List<UserMediaOptionEntity>) {}
+        override suspend fun upsert(attribute: UserMediaOptionEntity) {}
+        override suspend fun upsert(attribute: List<UserMediaOptionEntity>) {}
+    }
+
+    private class FakeUserNotificationLocalSource : UserNotificationLocalSource() {
+        override suspend fun count(): Int = 0
+        override suspend fun clear() {}
+        override suspend fun insert(attribute: UserNotificationEntity): Long = 0L
+        override suspend fun insert(attribute: List<UserNotificationEntity>): List<Long> = emptyList()
+        override suspend fun update(attribute: UserNotificationEntity) {}
+        override suspend fun update(attribute: List<UserNotificationEntity>) {}
+        override suspend fun delete(attribute: UserNotificationEntity) {}
+        override suspend fun delete(attribute: List<UserNotificationEntity>) {}
+        override suspend fun upsert(attribute: UserNotificationEntity) {}
+        override suspend fun upsert(attribute: List<UserNotificationEntity>) {}
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/auth/mapper/AuthenticatedUserWriterTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/auth/mapper/AuthenticatedUserWriterTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.auth.mapper
+
+import co.anitrend.data.user.datasource.local.UserLocalSource
+import co.anitrend.data.user.entity.UserEntity
+import co.anitrend.data.user.entity.view.UserEntityView
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthenticatedUserWriterTest {
+    @Test
+    fun `given authenticated user when persisting then user and option writers are invoked`() = runBlocking {
+        val localSource = FakeUserLocalSource()
+        val generalOptionWriter = FakeUserGeneralOptionWriter()
+        val mediaOptionWriter = FakeUserMediaOptionWriter()
+        val notificationWriter = FakeNotificationWriter()
+        val writer =
+            AuthenticatedUserWriter(
+                generalOptionWriter = generalOptionWriter,
+                mediaOptionWriter = mediaOptionWriter,
+                notificationMapper = notificationWriter,
+                localSource = localSource,
+            )
+
+        val user =
+            UserEntity(
+                about = UserEntity.About(name = "viewer", bio = null, siteUrl = "https://anilist.co/user/viewer", donatorTier = null, donatorBadge = null),
+                status = UserEntity.Status(isFollowing = false, isFollower = false, isBlocked = false),
+                coverImage = UserEntity.CoverImage(),
+                updatedAt = null,
+                createdAt = null,
+                id = 1L,
+            )
+
+        writer.persist(user)
+
+        assertEquals(listOf(1L), localSource.upsertedUserIds)
+        assertEquals(1, generalOptionWriter.invocationCount)
+        assertEquals(1, mediaOptionWriter.invocationCount)
+        assertEquals(1, notificationWriter.invocationCount)
+    }
+
+    private class FakeUserGeneralOptionWriter : UserGeneralOptionWriterContract {
+        var invocationCount = 0
+
+        override suspend fun persist() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeUserMediaOptionWriter : UserMediaOptionWriterContract {
+        var invocationCount = 0
+
+        override suspend fun persist() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeNotificationWriter : NotificationPersistence {
+        var invocationCount = 0
+
+        override suspend fun persistEmbedded() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeUserLocalSource : UserLocalSource() {
+        val upsertedUserIds = mutableListOf<Long>()
+
+        override suspend fun count(): Int = 0
+        override suspend fun clear() {}
+        override suspend fun clearById(id: Long) {}
+        override suspend fun clearByUserName(userName: String) {}
+        override suspend fun clearByMatch(userName: String) {}
+        override suspend fun userById(id: Long): UserEntity? = null
+        override suspend fun userById(ids: List<Long>): List<UserEntity> = emptyList()
+        override fun userByIdFlow(id: Long): Flow<UserEntity?> = flowOf(null)
+        override fun userByNameFlow(userName: String): Flow<UserEntity?> = flowOf(null)
+        override fun userAuthenticated(userId: Long): Flow<UserEntityView.Authenticated?> = flowOf(null)
+        override fun userByNameWithOptionsFlow(userName: String): Flow<UserEntityView.WithOptions?> = flowOf(null)
+        override fun userByIdWithOptionsFlow(id: Long): Flow<UserEntityView.WithOptions?> = flowOf(null)
+        override fun userByIdWithStatisticFlow(id: Long): Flow<UserEntityView.WithStatistic?> = flowOf(null)
+        override suspend fun insert(attribute: UserEntity): Long = 0L
+        override suspend fun insert(attribute: List<UserEntity>): List<Long> = emptyList()
+        override suspend fun update(attribute: UserEntity) {}
+        override suspend fun update(attribute: List<UserEntity>) {}
+        override suspend fun delete(attribute: UserEntity) {}
+        override suspend fun delete(attribute: List<UserEntity>) {}
+        override suspend fun upsert(attribute: UserEntity) { upsertedUserIds += attribute.id }
+        override suspend fun upsert(attribute: List<UserEntity>) { upsertedUserIds += attribute.map { it.id } }
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/media/mapper/MediaStatsMapperTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/media/mapper/MediaStatsMapperTest.kt
@@ -33,8 +33,8 @@ class MediaStatsMapperTest {
     fun `given normalized stats when persisting then transaction runner stores parent and distributions`() =
         runBlocking {
             val transactionRunner = FakeTransactionRunner()
-            val localSource = FakeMediaStatsLocalSource()
-            val mapper = MediaStatsMapper(localSource = localSource, transactionRunner = transactionRunner)
+            val writer = FakeMediaStatsWriter()
+            val mapper = MediaStatsMapper(writer = writer, transactionRunner = transactionRunner)
 
             mapper.onResponseDatabaseInsert(
                 MediaStatsMapper.Payload(
@@ -51,9 +51,9 @@ class MediaStatsMapperTest {
             )
 
             assertEquals(1, transactionRunner.invocationCount)
-            assertEquals(listOf(42L), localSource.upsertedStatsIds)
-            assertEquals(listOf(90), localSource.upsertedScores.map(MediaScoreDistributionEntity::score))
-            assertEquals(listOf("CURRENT"), localSource.upsertedStatuses.map(MediaStatusDistributionEntity::status))
+            assertEquals(listOf(42L), writer.upsertedStatsIds)
+            assertEquals(listOf(90), writer.upsertedScores.map(MediaScoreDistributionEntity::score))
+            assertEquals(listOf("CURRENT"), writer.upsertedStatuses.map(MediaStatusDistributionEntity::status))
         }
 
     private class FakeTransactionRunner : TransactionRunner {
@@ -65,63 +65,15 @@ class MediaStatsMapperTest {
         }
     }
 
-    private class FakeMediaStatsLocalSource : MediaStatsLocalSource() {
+    private class FakeMediaStatsWriter : MediaStatsWriterContract {
         val upsertedStatsIds = mutableListOf<Long>()
         val upsertedScores = mutableListOf<MediaScoreDistributionEntity>()
         val upsertedStatuses = mutableListOf<MediaStatusDistributionEntity>()
 
-        override suspend fun count(): Int = 0
-
-        override suspend fun clearScoreDistributions() {
-        }
-
-        override suspend fun clearStatusDistributions() {
-        }
-
-        override suspend fun clearScoreDistributionsByMediaId(mediaId: Long) {
-        }
-
-        override suspend fun clearStatusDistributionsByMediaId(mediaId: Long) {
-        }
-
-        override suspend fun clearStats() {
-        }
-
-        override fun entryByMediaIdFlow(mediaId: Long): Flow<MediaStatsEntityView?> = flowOf(null)
-
-        override suspend fun clearStatsByMediaId(mediaId: Long) {
-        }
-
-        override suspend fun upsert(attribute: MediaStatsEntity) {
-            upsertedStatsIds += attribute.id
-        }
-
-        override suspend fun upsertScoreDistributions(attribute: List<MediaScoreDistributionEntity>) {
-            upsertedScores += attribute
-        }
-
-        override suspend fun upsertStatusDistributions(attribute: List<MediaStatusDistributionEntity>) {
-            upsertedStatuses += attribute
-        }
-
-        override suspend fun insert(attribute: MediaStatsEntity): Long = 0L
-
-        override suspend fun insert(attribute: List<MediaStatsEntity>): List<Long> = emptyList()
-
-        override suspend fun update(attribute: MediaStatsEntity) {
-        }
-
-        override suspend fun update(attribute: List<MediaStatsEntity>) {
-        }
-
-        override suspend fun delete(attribute: MediaStatsEntity) {
-        }
-
-        override suspend fun delete(attribute: List<MediaStatsEntity>) {
-        }
-
-        override suspend fun upsert(attribute: List<MediaStatsEntity>) {
-            upsertedStatsIds += attribute.map(MediaStatsEntity::id)
+        override suspend fun persist(payload: MediaStatsMapper.Payload) {
+            upsertedStatsIds += payload.stats.id
+            upsertedScores += payload.scoreDistribution
+            upsertedStatuses += payload.statusDistribution
         }
     }
 }

--- a/data/src/test/kotlin/co/anitrend/data/media/mapper/MediaWriterTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/media/mapper/MediaWriterTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.media.mapper
+
+import androidx.paging.PagingSource
+import androidx.sqlite.db.SupportSQLiteQuery
+import co.anitrend.data.airing.entity.AiringScheduleEntity
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.media.datasource.local.MediaLocalSource
+import co.anitrend.data.media.entity.MediaEntity
+import co.anitrend.data.media.entity.connection.MediaCharacterConnectionEntity
+import co.anitrend.data.media.entity.connection.MediaStaffConnectionEntity
+import co.anitrend.data.media.entity.view.MediaEntityView
+import co.anitrend.data.common.CountryCode
+import co.anitrend.domain.media.enums.MediaType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MediaWriterTest {
+    @Test
+    fun `paged writer flushes tag genre airing and media list after local upsert`() = runBlocking {
+        val localSource = FakeMediaLocalSource()
+        val writer =
+            MediaPagedWriter(
+                localSource = localSource,
+                tagPersistence = FakePersistEmbedded(),
+                genrePersistence = FakePersistEmbedded(),
+                airingPersistence = FakePersistEmbedded(),
+                mediaListPersistence = FakePersistEmbedded(),
+            )
+
+        writer.persist(listOf(mediaEntity(1L), mediaEntity(2L)))
+
+        assertEquals(listOf(1L, 2L), localSource.upsertedListIds)
+    }
+
+    @Test
+    fun `detail writer flushes embedded writers after local upsert`() = runBlocking {
+        val localSource = FakeMediaLocalSource()
+        val link = FakePersistEmbedded()
+        val rank = FakePersistEmbedded()
+        val tag = FakePersistEmbedded()
+        val genre = FakePersistEmbedded()
+        val airing = FakePersistEmbedded()
+        val mediaList = FakePersistEmbedded()
+        val writer =
+            MediaDetailWriter(
+                localSource = localSource,
+                linkPersistence = link,
+                rankPersistence = rank,
+                tagPersistence = tag,
+                genrePersistence = genre,
+                airingPersistence = airing,
+                mediaListPersistence = mediaList,
+            )
+
+        writer.persist(mediaEntity(3L))
+
+        assertEquals(listOf(3L), localSource.upsertedSingleIds)
+        assertEquals(1, link.invocationCount)
+        assertEquals(1, rank.invocationCount)
+        assertEquals(1, tag.invocationCount)
+        assertEquals(1, genre.invocationCount)
+        assertEquals(1, airing.invocationCount)
+        assertEquals(1, mediaList.invocationCount)
+    }
+
+    @Test
+    fun `embed writer flushes tag and genre after local upsert`() = runBlocking {
+        val localSource = FakeMediaLocalSource()
+        val tag = FakePersistEmbedded()
+        val genre = FakePersistEmbedded()
+        val writer = MediaEmbedWriter(localSource = localSource, tagPersistence = tag, genrePersistence = genre)
+
+        writer.persist(listOf(mediaEntity(5L)))
+
+        assertEquals(listOf(5L), localSource.upsertedListIds)
+        assertEquals(1, tag.invocationCount)
+        assertEquals(1, genre.invocationCount)
+    }
+
+    @Test
+    fun `embed with airing writer flushes tag genre and airing after local upsert`() = runBlocking {
+        val localSource = FakeMediaLocalSource()
+        val tag = FakePersistEmbedded()
+        val genre = FakePersistEmbedded()
+        val airing = FakePersistEmbedded()
+        val writer =
+            MediaEmbedWithAiringWriter(
+                localSource = localSource,
+                tagPersistence = tag,
+                genrePersistence = genre,
+                airingPersistence = airing,
+            )
+
+        writer.persist(listOf(mediaEntity(7L)))
+
+        assertEquals(listOf(7L), localSource.upsertedListIds)
+        assertEquals(1, tag.invocationCount)
+        assertEquals(1, genre.invocationCount)
+        assertEquals(1, airing.invocationCount)
+    }
+
+    @Test
+    fun `embed with media list writer flushes tag genre airing and media list after local upsert`() = runBlocking {
+        val localSource = FakeMediaLocalSource()
+        val tag = FakePersistEmbedded()
+        val genre = FakePersistEmbedded()
+        val airing = FakePersistEmbedded()
+        val mediaList = FakePersistEmbedded()
+        val writer =
+            MediaEmbedWithMediaListWriter(
+                localSource = localSource,
+                tagPersistence = tag,
+                genrePersistence = genre,
+                airingPersistence = airing,
+                mediaListPersistence = mediaList,
+            )
+
+        writer.persist(listOf(mediaEntity(11L)))
+
+        assertEquals(listOf(11L), localSource.upsertedListIds)
+        assertEquals(1, tag.invocationCount)
+        assertEquals(1, genre.invocationCount)
+        assertEquals(1, airing.invocationCount)
+        assertEquals(1, mediaList.invocationCount)
+    }
+
+    private fun mediaEntity(id: Long) =
+        MediaEntity(
+            coverImage = MediaEntity.CoverImage(color = null, extraLarge = null, large = null, medium = null, banner = null),
+            title = MediaEntity.Title(romaji = "Title $id", english = null, original = null, userPreferred = "Title $id"),
+            trailer = null,
+            nextAiringId = null,
+            averageScore = null,
+            chapters = null,
+            countryOfOrigin = "JP",
+            description = null,
+            duration = null,
+            endDate = null,
+            episodes = null,
+            favourites = 0,
+            format = null,
+            hashTag = null,
+            isAdult = false,
+            isFavourite = false,
+            isFavouriteBlocked = false,
+            isLicensed = null,
+            isRecommendationBlocked = false,
+            isReviewBlocked = false,
+            isLocked = null,
+            meanScore = null,
+            popularity = null,
+            season = null,
+            siteUrl = null,
+            source = null,
+            startDate = null,
+            status = null,
+            synonyms = emptyList(),
+            trending = null,
+            type = MediaType.ANIME,
+            updatedAt = null,
+            volumes = null,
+            malId = null,
+            id = id,
+        )
+
+    private class FakePersistEmbedded : PersistEmbedded {
+        var invocationCount = 0
+
+        override suspend fun persistEmbedded() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeMediaLocalSource : MediaLocalSource() {
+        val upsertedSingleIds = mutableListOf<Long>()
+        val upsertedListIds = mutableListOf<Long>()
+
+        override suspend fun count(): Int = 0
+        override suspend fun clear() {}
+        override suspend fun clearById(id: Long) {}
+        override fun mediaByIdFlow(id: Long): Flow<MediaEntityView.Extended?> = flowOf(null)
+        override fun rawFlow(query: SupportSQLiteQuery): Flow<MediaEntityView.Core?> = flowOf(null)
+        override fun rawPagingSource(query: SupportSQLiteQuery): PagingSource<Int, MediaEntityView.Core> = throw NotImplementedError()
+        override fun mediaCharactersPagingSource(mediaId: Long): PagingSource<Int, MediaCharacterConnectionEntity> = throw NotImplementedError()
+        override fun mediaStaffPagingSource(mediaId: Long): PagingSource<Int, MediaStaffConnectionEntity> = throw NotImplementedError()
+        override suspend fun mediaCharactersCount(mediaId: Long): Int = 0
+        override suspend fun mediaCharactersMaxSortIndex(mediaId: Long): Int? = null
+        override suspend fun mediaStaffCount(mediaId: Long): Int = 0
+        override suspend fun mediaStaffMaxSortIndex(mediaId: Long): Int? = null
+        override suspend fun clearMediaCharactersByMediaId(mediaId: Long) {}
+        override suspend fun clearMediaStaffByMediaId(mediaId: Long) {}
+        override suspend fun upsertMediaCharacters(attribute: List<MediaCharacterConnectionEntity>) {}
+        override suspend fun upsertMediaStaff(attribute: List<MediaStaffConnectionEntity>) {}
+        override suspend fun insert(attribute: MediaEntity): Long = 0L
+        override suspend fun insert(attribute: List<MediaEntity>): List<Long> = emptyList()
+        override suspend fun update(attribute: MediaEntity) {}
+        override suspend fun update(attribute: List<MediaEntity>) {}
+        override suspend fun delete(attribute: MediaEntity) {}
+        override suspend fun delete(attribute: List<MediaEntity>) {}
+        override suspend fun upsert(attribute: MediaEntity) { upsertedSingleIds += attribute.id }
+        override suspend fun upsert(attribute: List<MediaEntity>) { upsertedListIds += attribute.map(MediaEntity::id) }
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/medialist/mapper/MediaListEmbedWriterTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/medialist/mapper/MediaListEmbedWriterTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.medialist.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.medialist.datasource.local.MediaListLocalSource
+import co.anitrend.data.medialist.entity.MediaListEntity
+import co.anitrend.domain.media.enums.MediaType
+import co.anitrend.domain.medialist.enums.MediaListStatus
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MediaListEmbedWriterTest {
+    @Test
+    fun `given embedded media list entities when persisting then user custom list and custom score are flushed`() =
+        runBlocking {
+            val userPersistence = FakePersistEmbedded()
+            val customListPersistence = FakePersistEmbedded()
+            val customScorePersistence = FakePersistEmbedded()
+            val localSource = FakeMediaListLocalSource()
+            val writer =
+                MediaListEmbedWriter(
+                    userPersistence = userPersistence,
+                    localSource = localSource,
+                    customListPersistence = customListPersistence,
+                    customScorePersistence = customScorePersistence,
+                )
+
+            writer.persist(listOf(mediaListEntity(id = 3L), mediaListEntity(id = 5L)))
+
+            assertEquals(listOf(3L, 5L), localSource.upsertedListIds)
+            assertEquals(1, userPersistence.invocationCount)
+            assertEquals(1, customListPersistence.invocationCount)
+            assertEquals(1, customScorePersistence.invocationCount)
+        }
+
+    @Test
+    fun `given embedded media list entities with media when persisting then user and media are flushed`() =
+        runBlocking {
+            val userPersistence = FakePersistEmbedded()
+            val mediaPersistence = FakePersistEmbedded()
+            val localSource = FakeMediaListLocalSource()
+            val writer =
+                MediaListEmbedWithMediaWriter(
+                    userPersistence = userPersistence,
+                    mediaPersistence = mediaPersistence,
+                    localSource = localSource,
+                )
+
+            writer.persist(listOf(mediaListEntity(id = 7L), mediaListEntity(id = 11L)))
+
+            assertEquals(listOf(7L, 11L), localSource.upsertedListIds)
+            assertEquals(1, userPersistence.invocationCount)
+            assertEquals(1, mediaPersistence.invocationCount)
+        }
+
+    private fun mediaListEntity(id: Long) =
+        MediaListEntity(
+            mediaType = MediaType.ANIME,
+            completedAt = null,
+            createdAt = null,
+            hiddenFromStatus = false,
+            mediaId = id * 10,
+            notes = null,
+            priority = null,
+            hidden = false,
+            progress = 0,
+            progressVolumes = 0,
+            repeatCount = 0,
+            score = 0f,
+            startedAt = null,
+            status = MediaListStatus.CURRENT,
+            updatedAt = null,
+            userId = 1L,
+            userName = "viewer",
+            id = id,
+        )
+
+    private class FakePersistEmbedded : PersistEmbedded {
+        var invocationCount = 0
+
+        override suspend fun persistEmbedded() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeMediaListLocalSource : MediaListLocalSource() {
+        val upsertedListIds = mutableListOf<Long>()
+
+        override suspend fun count(): Int = 0
+
+        override suspend fun clear() {
+        }
+
+        override suspend fun clearById(id: Long, userId: Long) {
+        }
+
+        override suspend fun clearByUserId(userId: Long) {
+        }
+
+        override suspend fun clearByUserName(userName: String) {
+        }
+
+        override suspend fun clearByMediaId(mediaId: Long, userId: Long) {
+        }
+
+        override suspend fun insert(attribute: MediaListEntity): Long = 0L
+
+        override suspend fun insert(attribute: List<MediaListEntity>): List<Long> = emptyList()
+
+        override suspend fun update(attribute: MediaListEntity) {
+        }
+
+        override suspend fun update(attribute: List<MediaListEntity>) {
+        }
+
+        override suspend fun delete(attribute: MediaListEntity) {
+        }
+
+        override suspend fun delete(attribute: List<MediaListEntity>) {
+        }
+
+        override suspend fun upsert(attribute: MediaListEntity) {
+        }
+
+        override suspend fun upsert(attribute: List<MediaListEntity>) {
+            upsertedListIds += attribute.map(MediaListEntity::id)
+        }
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/medialist/mapper/MediaListWriterTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/medialist/mapper/MediaListWriterTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.medialist.mapper
+
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.medialist.datasource.local.MediaListLocalSource
+import co.anitrend.data.medialist.entity.MediaListEntity
+import co.anitrend.domain.media.enums.MediaType
+import co.anitrend.domain.medialist.enums.MediaListStatus
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MediaListWriterTest {
+    @Test
+    fun `given single media list entity when persisting then embedded writers and local source are invoked`() =
+        runBlocking {
+            val userPersistence = FakePersistEmbedded()
+            val mediaPersistence = FakePersistEmbedded()
+            val customListPersistence = FakePersistEmbedded()
+            val customScorePersistence = FakePersistEmbedded()
+            val localSource = FakeMediaListLocalSource()
+            val writer =
+                MediaListWriter(
+                    userPersistence = userPersistence,
+                    mediaPersistence = mediaPersistence,
+                    localSource = localSource,
+                    customListPersistence = customListPersistence,
+                    customScorePersistence = customScorePersistence,
+                )
+
+            writer.persist(mediaListEntity(id = 7L))
+
+            assertEquals(listOf(7L), localSource.upsertedSingleIds)
+            assertEquals(1, userPersistence.invocationCount)
+            assertEquals(1, mediaPersistence.invocationCount)
+            assertEquals(1, customListPersistence.invocationCount)
+            assertEquals(1, customScorePersistence.invocationCount)
+        }
+
+    @Test
+    fun `given media list entities when persisting then embedded writers and local source are invoked once`() =
+        runBlocking {
+            val userPersistence = FakePersistEmbedded()
+            val mediaPersistence = FakePersistEmbedded()
+            val customListPersistence = FakePersistEmbedded()
+            val customScorePersistence = FakePersistEmbedded()
+            val localSource = FakeMediaListLocalSource()
+            val writer =
+                MediaListWriter(
+                    userPersistence = userPersistence,
+                    mediaPersistence = mediaPersistence,
+                    localSource = localSource,
+                    customListPersistence = customListPersistence,
+                    customScorePersistence = customScorePersistence,
+                )
+
+            writer.persist(
+                listOf(
+                    mediaListEntity(id = 11L),
+                    mediaListEntity(id = 13L),
+                ),
+            )
+
+            assertEquals(listOf(11L, 13L), localSource.upsertedListIds)
+            assertEquals(1, userPersistence.invocationCount)
+            assertEquals(1, mediaPersistence.invocationCount)
+            assertEquals(1, customListPersistence.invocationCount)
+            assertEquals(1, customScorePersistence.invocationCount)
+        }
+
+    private fun mediaListEntity(id: Long) =
+        MediaListEntity(
+            mediaType = MediaType.ANIME,
+            completedAt = null,
+            createdAt = null,
+            hiddenFromStatus = false,
+            mediaId = id * 10,
+            notes = null,
+            priority = null,
+            hidden = false,
+            progress = 0,
+            progressVolumes = 0,
+            repeatCount = 0,
+            score = 0f,
+            startedAt = null,
+            status = MediaListStatus.CURRENT,
+            updatedAt = null,
+            userId = 1L,
+            userName = "viewer",
+            id = id,
+        )
+
+    private class FakePersistEmbedded : PersistEmbedded {
+        var invocationCount = 0
+
+        override suspend fun persistEmbedded() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeMediaListLocalSource : MediaListLocalSource() {
+        val upsertedSingleIds = mutableListOf<Long>()
+        val upsertedListIds = mutableListOf<Long>()
+
+        override suspend fun count(): Int = 0
+
+        override suspend fun clear() {
+        }
+
+        override suspend fun clearById(id: Long, userId: Long) {
+        }
+
+        override suspend fun clearByUserId(userId: Long) {
+        }
+
+        override suspend fun clearByUserName(userName: String) {
+        }
+
+        override suspend fun clearByMediaId(mediaId: Long, userId: Long) {
+        }
+
+        override suspend fun insert(attribute: MediaListEntity): Long = 0L
+
+        override suspend fun insert(attribute: List<MediaListEntity>): List<Long> = emptyList()
+
+        override suspend fun update(attribute: MediaListEntity) {
+        }
+
+        override suspend fun update(attribute: List<MediaListEntity>) {
+        }
+
+        override suspend fun delete(attribute: MediaListEntity) {
+        }
+
+        override suspend fun delete(attribute: List<MediaListEntity>) {
+        }
+
+        override suspend fun upsert(attribute: MediaListEntity) {
+            upsertedSingleIds += attribute.id
+        }
+
+        override suspend fun upsert(attribute: List<MediaListEntity>) {
+            upsertedListIds += attribute.map(MediaListEntity::id)
+        }
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/review/mapper/ReviewWriterTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/review/mapper/ReviewWriterTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ */
+package co.anitrend.data.review.mapper
+
+import androidx.paging.PagingSource
+import androidx.sqlite.db.SupportSQLiteQuery
+import co.anitrend.data.android.mapper.PersistEmbedded
+import co.anitrend.data.review.datasource.local.ReviewLocalSource
+import co.anitrend.data.review.entity.ReviewEntity
+import co.anitrend.data.review.entity.view.ReviewEntityView
+import co.anitrend.domain.review.enums.ReviewRating
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ReviewWriterTest {
+    @Test
+    fun `given review entity when persisting then media is flushed before local upsert`() =
+        runBlocking {
+            val mediaPersistence = FakePersistEmbedded()
+            val userPersistence = FakePersistEmbedded()
+            val localSource = FakeReviewLocalSource()
+            val writer = ReviewWriter(mediaPersistence = mediaPersistence, userPersistence = userPersistence, localSource = localSource)
+
+            writer.persist(reviewEntity(id = 5L))
+
+            assertEquals(listOf(5L), localSource.upsertedSingleIds)
+            assertEquals(1, mediaPersistence.invocationCount)
+            assertEquals(0, userPersistence.invocationCount)
+        }
+
+    @Test
+    fun `given review entities when persisting then media and user are flushed before local upsert`() =
+        runBlocking {
+            val mediaPersistence = FakePersistEmbedded()
+            val userPersistence = FakePersistEmbedded()
+            val localSource = FakeReviewLocalSource()
+            val writer = ReviewWriter(mediaPersistence = mediaPersistence, userPersistence = userPersistence, localSource = localSource)
+
+            writer.persist(listOf(reviewEntity(id = 7L), reviewEntity(id = 11L)))
+
+            assertEquals(listOf(7L, 11L), localSource.upsertedListIds)
+            assertEquals(1, mediaPersistence.invocationCount)
+            assertEquals(1, userPersistence.invocationCount)
+        }
+
+    private fun reviewEntity(id: Long) =
+        ReviewEntity(
+            body = "body",
+            createdAt = 1L,
+            mediaId = 2L,
+            isPrivate = false,
+            rating = 0,
+            ratingAmount = 0,
+            score = 0,
+            siteUrl = "https://anilist.co/review/$id",
+            summary = "summary",
+            updatedAt = 1L,
+            userId = 3L,
+            userRating = ReviewRating.NO_VOTE,
+            id = id,
+        )
+
+    private class FakePersistEmbedded : PersistEmbedded {
+        var invocationCount = 0
+
+        override suspend fun persistEmbedded() {
+            invocationCount += 1
+        }
+    }
+
+    private class FakeReviewLocalSource : ReviewLocalSource() {
+        val upsertedSingleIds = mutableListOf<Long>()
+        val upsertedListIds = mutableListOf<Long>()
+
+        override suspend fun count(): Int = 0
+
+        override suspend fun clear() {
+        }
+
+        override suspend fun clearById(id: Long) {
+        }
+
+        override fun rawFlow(query: SupportSQLiteQuery): Flow<ReviewEntityView.Core?> = flowOf(null)
+
+        override fun rawPagingSource(query: SupportSQLiteQuery): PagingSource<Int, ReviewEntityView.Core> =
+            throw NotImplementedError()
+
+        override fun entryByUserIdFlow(userId: Long): Flow<List<ReviewEntity>> = flowOf(emptyList())
+
+        override suspend fun insert(attribute: ReviewEntity): Long = 0L
+
+        override suspend fun insert(attribute: List<ReviewEntity>): List<Long> = emptyList()
+
+        override suspend fun update(attribute: ReviewEntity) {
+        }
+
+        override suspend fun update(attribute: List<ReviewEntity>) {
+        }
+
+        override suspend fun delete(attribute: ReviewEntity) {
+        }
+
+        override suspend fun delete(attribute: List<ReviewEntity>) {
+        }
+
+        override suspend fun upsert(attribute: ReviewEntity) {
+            upsertedSingleIds += attribute.id
+        }
+
+        override suspend fun upsert(attribute: List<ReviewEntity>) {
+            upsertedListIds += attribute.map(ReviewEntity::id)
+        }
+    }
+}

--- a/data/src/test/kotlin/co/anitrend/data/user/mapper/UserMapperTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/user/mapper/UserMapperTest.kt
@@ -21,6 +21,8 @@ import co.anitrend.data.android.source.local.AbstractLocalSource
 import co.anitrend.data.user.converter.UserGeneralOptionModelConverter
 import co.anitrend.data.user.converter.UserMediaOptionModelConverter
 import co.anitrend.data.user.converter.UserModelConverter
+import co.anitrend.data.user.converter.UserStatisticPayload
+import co.anitrend.data.user.converter.UserStatisticModelConverter
 import co.anitrend.data.user.datasource.local.UserLocalSource
 import co.anitrend.data.user.datasource.local.option.UserGeneralOptionLocalSource
 import co.anitrend.data.user.datasource.local.option.UserMediaOptionLocalSource
@@ -56,6 +58,7 @@ class UserMapperTest {
         runBlocking {
             val transactionRunner = FakeTransactionRunner()
             val localSource = FakeUserLocalSource()
+            val writer = FakeUserProfileWriter()
             val mapper =
                 UserMapper.Profile(
                     generalOptionMapper =
@@ -72,6 +75,7 @@ class UserMapperTest {
                         UserMapper.PreviousNameEmbed(
                             localSource = FakeUserPreviousNameLocalSource(),
                         ),
+                    writer = writer,
                     localSource = localSource,
                     transactionRunner = transactionRunner,
                     converter = UserModelConverter(),
@@ -79,8 +83,60 @@ class UserMapperTest {
 
             mapper.onResponseDatabaseInsert(userEntity())
 
-            assertEquals(listOf(1L), localSource.upsertedUserIds)
             assertEquals(1, transactionRunner.invocationCount)
+            assertEquals(listOf(1L), writer.persistedUserIds)
+        }
+
+    @Test
+    fun `given statistic mapper when persisting payload then writer is invoked inside transaction`() =
+        runBlocking {
+            val transactionRunner = FakeTransactionRunner()
+            val writer = FakeUserStatisticPersistenceWriter()
+            val mapper =
+                UserMapper.Statistic(
+                    userMapper = UserMapper.Embed(localSource = FakeUserLocalSource(), converter = UserModelConverter()),
+                    writer = writer,
+                    converter = UserStatisticModelConverter(),
+                    transactionRunner = transactionRunner,
+                )
+
+            val payload =
+                UserStatisticPayload(
+                    statistic = co.anitrend.data.user.entity.statistic.UserWithStatisticEntity(
+                        statistic =
+                            co.anitrend.data.user.entity.statistic.UserWithStatisticEntity.Statistic(
+                                animeCount = 1,
+                                animeMeanScore = 80f,
+                                animeStandardDeviation = 0f,
+                                animeMinutesWatched = 24,
+                                animeEpisodesWatched = 1,
+                                mangaCount = null,
+                                mangaMeanScore = null,
+                                mangaStandardDeviation = null,
+                                mangaChaptersRead = null,
+                                mangaVolumesRead = null,
+                            ),
+                        userId = 1L,
+                        id = 1L,
+                    ),
+                    countries = emptyList(),
+                    formats = emptyList(),
+                    genres = emptyList(),
+                    lengths = emptyList(),
+                    releaseYears = emptyList(),
+                    scores = emptyList(),
+                    staff = emptyList(),
+                    startYears = emptyList(),
+                    statuses = emptyList(),
+                    studios = emptyList(),
+                    tags = emptyList(),
+                    voiceActors = emptyList(),
+                )
+
+            mapper.onResponseDatabaseInsert(payload)
+
+            assertEquals(1, transactionRunner.invocationCount)
+            assertEquals(listOf(payload), writer.persisted)
         }
 
     private fun userEntity() =
@@ -111,6 +167,22 @@ class UserMapperTest {
         override suspend fun run(block: suspend () -> Unit) {
             invocationCount += 1
             block()
+        }
+    }
+
+    private class FakeUserStatisticPersistenceWriter : UserStatisticPersistenceWriterContract {
+        val persisted = mutableListOf<UserStatisticPayload>()
+
+        override suspend fun persist(payload: UserStatisticPayload) {
+            persisted += payload
+        }
+    }
+
+    private class FakeUserProfileWriter : UserProfileWriterContract {
+        val persistedUserIds = mutableListOf<Long>()
+
+        override suspend fun persist(user: UserEntity) {
+            persistedUserIds += user.id
         }
     }
 

--- a/data/src/test/kotlin/co/anitrend/data/user/mapper/UserProfileFeedMapperTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/user/mapper/UserProfileFeedMapperTest.kt
@@ -28,19 +28,45 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class UserProfileFeedMapperTest {
+    @Test
+    fun `persist uses feed writer inside transaction`() = runBlocking {
+        val transactionRunner = FakeTransactionRunner()
+        val writer = FakeUserProfileFeedWriter()
+        val mapper =
+            UserProfileFeedMapper(
+                reviewConnectionMapper = UserProfileConnectionMapper.ReviewEmbed(FakeUserProfileReviewLocalSource()),
+                reviewPreviewMapper = ReviewMapper.PreviewEmbed(FakeReviewLocalSource()),
+                statusEmbedMapper = StatusMapper.Activity.Embed(FakeStatusLocalSource()),
+                mediaEmbedMapper = FakeMediaEmbedMapper(),
+                writer = writer,
+                transactionRunner = transactionRunner,
+            )
+
+        mapper.onResponseDatabaseInsert(Unit)
+
+        assertEquals(1, transactionRunner.invocationCount)
+        assertEquals(1, writer.invocationCount)
+    }
+
     @Test
     fun `onResponseMapFrom persists review and activity rows`() = runBlocking {
         val reviewConnectionLocalSource = FakeUserProfileReviewLocalSource()
         val reviewLocalSource = FakeReviewLocalSource()
         val statusLocalSource = FakeStatusLocalSource()
+        val mediaEmbedMapper = FakeMediaEmbedMapper()
+        val reviewConnectionMapper = UserProfileConnectionMapper.ReviewEmbed(reviewConnectionLocalSource)
+        val reviewPreviewMapper = ReviewMapper.PreviewEmbed(reviewLocalSource)
+        val statusEmbedMapper = StatusMapper.Activity.Embed(statusLocalSource)
         val mapper =
             UserProfileFeedMapper(
-                reviewConnectionMapper = UserProfileConnectionMapper.ReviewEmbed(reviewConnectionLocalSource),
-                reviewPreviewMapper = ReviewMapper.PreviewEmbed(reviewLocalSource),
-                statusEmbedMapper = StatusMapper.Activity.Embed(statusLocalSource),
-                mediaEmbedMapper = FakeMediaEmbedMapper(),
+                reviewConnectionMapper = reviewConnectionMapper,
+                reviewPreviewMapper = reviewPreviewMapper,
+                statusEmbedMapper = statusEmbedMapper,
+                mediaEmbedMapper = mediaEmbedMapper,
+                writer = UserProfileFeedWriter(mediaEmbedMapper, reviewPreviewMapper, reviewConnectionMapper, statusEmbedMapper),
                 transactionRunner = FakeTransactionRunner(),
             )
 
@@ -105,8 +131,19 @@ class UserProfileFeedMapperTest {
         )
 
     private class FakeTransactionRunner : TransactionRunner {
+        var invocationCount = 0
+
         override suspend fun run(block: suspend () -> Unit) {
+            invocationCount += 1
             block()
+        }
+    }
+
+    private class FakeUserProfileFeedWriter : UserProfileFeedWriterContract {
+        var invocationCount = 0
+
+        override suspend fun persist() {
+            invocationCount += 1
         }
     }
 

--- a/data/src/test/kotlin/co/anitrend/data/user/mapper/UserProfileOverviewMapperTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/user/mapper/UserProfileOverviewMapperTest.kt
@@ -29,14 +29,37 @@ import kotlin.test.assertEquals
 
 class UserProfileOverviewMapperTest {
     @Test
+    fun `persist uses overview writer inside transaction`() = runBlocking {
+        val transactionRunner = FakeTransactionRunner()
+        val writer = FakeUserProfileOverviewWriter()
+        val mapper =
+            UserProfileOverviewMapper(
+                favouriteEmbedMapper = UserProfileConnectionMapper.FavouriteEmbed(FakeUserProfileFavouriteMediaLocalSource()),
+                statusEmbedMapper = StatusMapper.Activity.Embed(FakeStatusLocalSource()),
+                mediaEmbedMapper = FakeMediaEmbedMapper(),
+                writer = writer,
+                transactionRunner = transactionRunner,
+            )
+
+        mapper.onResponseDatabaseInsert(Unit)
+
+        assertEquals(1, transactionRunner.invocationCount)
+        assertEquals(1, writer.invocationCount)
+    }
+
+    @Test
     fun `onResponseMapFrom and persist store favourites activities and embedded media`() = runBlocking {
         val favouriteLocalSource = FakeUserProfileFavouriteMediaLocalSource()
         val statusLocalSource = FakeStatusLocalSource()
+        val mediaEmbedMapper = FakeMediaEmbedMapper()
+        val favouriteEmbedMapper = UserProfileConnectionMapper.FavouriteEmbed(favouriteLocalSource)
+        val statusEmbedMapper = StatusMapper.Activity.Embed(statusLocalSource)
         val mapper =
             UserProfileOverviewMapper(
-                favouriteEmbedMapper = UserProfileConnectionMapper.FavouriteEmbed(favouriteLocalSource),
-                statusEmbedMapper = StatusMapper.Activity.Embed(statusLocalSource),
-                mediaEmbedMapper = FakeMediaEmbedMapper(),
+                favouriteEmbedMapper = favouriteEmbedMapper,
+                statusEmbedMapper = statusEmbedMapper,
+                mediaEmbedMapper = mediaEmbedMapper,
+                writer = UserProfileOverviewWriter(mediaEmbedMapper, favouriteEmbedMapper, statusEmbedMapper),
                 transactionRunner = FakeTransactionRunner(),
             )
 
@@ -99,6 +122,14 @@ class UserProfileOverviewMapperTest {
         override suspend fun run(block: suspend () -> Unit) {
             invocationCount += 1
             block()
+        }
+    }
+
+    private class FakeUserProfileOverviewWriter : UserProfileOverviewWriterContract {
+        var invocationCount = 0
+
+        override suspend fun persist() {
+            invocationCount += 1
         }
     }
 


### PR DESCRIPTION
# AniTrend Pull Request

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/AniTrend/anitrend-v2/blob/develop/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure you've done the following:

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-v2/blob/develop/CONTRIBUTING.md)
- [x] Double checked that your branch is based on `develop` and targets `develop` (where applicable)
- [x] Pull request has tests (if applicable)
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved

## Description
Closes #1178.

This refactor standardizes coordinated persistence across the data layer by moving multi-entity flush logic out of mapper `persist()` implementations and into module-owned writer contracts.

Included in this pass:
- shared `PersistEmbedded` abstraction for embed mapper composition
- writer extraction for auth, airing, media, media stats, media list, review, and user persistence paths
- mapper and Koin rewiring so orchestration sits behind dedicated writer boundaries
- focused regression tests covering each new writer slice and updated mapper delegation behavior

## Screenshots:
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [GPL v3 License](https://github.com/AniTrend/anitrend-v2/blob/develop/LICENSE.md).