### PR TITLE
fix(settings): mirror developer toggle state

### DIFF
--- a/android/core/src/main/kotlin/co/anitrend/android/core/koin/Modules.kt
+++ b/android/core/src/main/kotlin/co/anitrend/android/core/koin/Modules.kt
@@ -48,6 +48,7 @@ import co.anitrend.data.settings.cache.ICacheSettings
 import co.anitrend.data.settings.connectivity.IConnectivitySettings
 import co.anitrend.data.settings.customize.ICustomizationSettings
 import co.anitrend.data.settings.developer.IDeveloperSettings
+import co.anitrend.data.settings.feature.IFeatureFlagSetting
 import co.anitrend.data.settings.notification.INotificationSettings
 import co.anitrend.data.settings.power.IPowerSettings
 import co.anitrend.data.settings.privacy.IPrivacySettings
@@ -85,6 +86,7 @@ private val coreModule =
                 ICacheSettings::class,
                 ISyncSettings::class,
                 IDeveloperSettings::class,
+                IFeatureFlagSetting::class,
             )
 
         single<ISupportDispatcher> {

--- a/android/core/src/main/kotlin/co/anitrend/android/core/settings/Settings.kt
+++ b/android/core/src/main/kotlin/co/anitrend/android/core/settings/Settings.kt
@@ -27,6 +27,7 @@ import co.anitrend.arch.extension.settings.EnumSetting
 import co.anitrend.arch.extension.settings.FloatSetting
 import co.anitrend.arch.extension.settings.IntSetting
 import co.anitrend.arch.extension.settings.LongSetting
+import co.anitrend.arch.extension.settings.StringSetting
 import co.anitrend.data.auth.settings.IAuthenticationSettings
 import co.anitrend.data.auth.settings.IAuthenticationSettings.Companion.INVALID_USER_ID
 import co.anitrend.data.settings.cache.ICacheSettings
@@ -34,6 +35,8 @@ import co.anitrend.data.settings.connectivity.IConnectivitySettings
 import co.anitrend.data.settings.customize.ICustomizationSettings
 import co.anitrend.data.settings.customize.common.PreferredViewMode
 import co.anitrend.data.settings.developer.IDeveloperSettings
+import co.anitrend.data.settings.feature.FeatureFlags
+import co.anitrend.data.settings.feature.IFeatureFlagSetting
 import co.anitrend.data.settings.notification.INotificationSettings
 import co.anitrend.data.settings.power.IPowerSettings
 import co.anitrend.data.settings.privacy.IPrivacySettings
@@ -60,7 +63,8 @@ class Settings(
     IUserSettings,
     ICacheSettings,
     ISyncSettings,
-    IDeveloperSettings {
+    IDeveloperSettings,
+    IFeatureFlagSetting {
     override val locale =
         EnumSetting(
             key = R.string.settings_configuration_locale,
@@ -260,4 +264,30 @@ class Settings(
             resources = context.resources,
             preference = this,
         )
+
+    override val featureFlags =
+        StringSetting(
+            key = R.string.settings_feature_flags,
+            default = FeatureFlags.EMPTY,
+            resources = context.resources,
+            preference = this,
+        )
+
+    private val featureFlagsMigrated =
+        BooleanSetting(
+            key = R.string.settings_feature_flags_migrated,
+            default = false,
+            resources = context.resources,
+            preference = this,
+        )
+
+    init {
+        featureFlags.value =
+            FeatureFlags.migrateLegacyComposeUi(
+                csv = featureFlags.value,
+                legacyEnabled = experimentalComposeUi.value,
+                migrationComplete = featureFlagsMigrated.value,
+            )
+        featureFlagsMigrated.value = true
+    }
 }

--- a/android/core/src/main/res/values/settings.xml
+++ b/android/core/src/main/res/values/settings.xml
@@ -54,4 +54,6 @@
     <string name="settings_auto_heap_dump" translatable="false">_autoHeapDump</string>
     <string name="settings_show_leak_launcher" translatable="false">_showLeakLauncher</string>
     <string name="settings_experimental_compose_ui" translatable="false">_experimentalComposeUi</string>
+    <string name="settings_feature_flags" translatable="false">_featureFlags</string>
+    <string name="settings_feature_flags_migrated" translatable="false">_featureFlagsMigrated</string>
 </resources>

--- a/android/navigation/src/main/kotlin/co/anitrend/android/navigation/drawer/component/content/NavigationDrawerHostFragment.kt
+++ b/android/navigation/src/main/kotlin/co/anitrend/android/navigation/drawer/component/content/NavigationDrawerHostFragment.kt
@@ -20,10 +20,8 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
-import co.anitrend.arch.extension.ext.UNSAFE
 import co.anitrend.android.core.components.sheet.action.contract.OnSlideAction
 import co.anitrend.android.core.components.sheet.action.contract.OnStateChangedAction
-import co.anitrend.data.settings.developer.IDeveloperSettings
 import co.anitrend.android.navigation.compose.drawer.component.content.ComposeNavigationDrawerSheet
 import co.anitrend.android.navigation.drawer.R
 import co.anitrend.android.navigation.drawer.component.content.contract.INavigationDrawer
@@ -31,6 +29,9 @@ import co.anitrend.android.navigation.drawer.component.viewmodel.DrawerViewModel
 import co.anitrend.android.navigation.drawer.model.internal.DrawerEvent
 import co.anitrend.android.navigation.drawer.model.internal.DrawerLegacyNavigationAdapter
 import co.anitrend.android.navigation.drawer.model.navigation.Navigation
+import co.anitrend.data.settings.feature.FeatureFlag
+import co.anitrend.data.settings.feature.FeatureFlags
+import co.anitrend.data.settings.feature.IFeatureFlagSetting
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapNotNull
 import org.koin.android.ext.android.inject
@@ -40,14 +41,17 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 class NavigationDrawerHostFragment :
     Fragment(R.layout.navigation_drawer_host),
     INavigationDrawer {
-    private val developerSettings by inject<IDeveloperSettings>()
+    private val featureFlagSetting by inject<IFeatureFlagSetting>()
 
     private val drawerViewModel by viewModel<DrawerViewModel>(
         ownerProducer = { requireActivity() },
     )
 
-    private val useComposeDrawer by lazy(UNSAFE) {
-        developerSettings.experimentalComposeUi.value
+    private val useComposeDrawer: Boolean by lazy(LazyThreadSafetyMode.NONE) {
+        FeatureFlags.isEnabled(
+            csv = featureFlagSetting.featureFlags.value,
+            flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
+        )
     }
 
     private val pendingSlideActions = linkedSetOf<OnSlideAction>()

--- a/app/navigation/src/main/kotlin/co/anitrend/navigation/NavigationTargets.kt
+++ b/app/navigation/src/main/kotlin/co/anitrend/navigation/NavigationTargets.kt
@@ -135,6 +135,7 @@ object SettingsRouter : NavigationRouter() {
         SYNCHRONIZATION,
         STORAGE,
         DEVELOPER,
+        FEATURE_FLAGS,
         LOGS,
         TASK,
     }

--- a/data/settings/src/main/kotlin/co/anitrend/data/settings/feature/IFeatureFlagSetting.kt
+++ b/data/settings/src/main/kotlin/co/anitrend/data/settings/feature/IFeatureFlagSetting.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package co.anitrend.data.settings.feature
+
+import co.anitrend.arch.extension.settings.contract.AbstractSetting
+
+interface IFeatureFlagSetting {
+    val featureFlags: AbstractSetting<String>
+}
+
+enum class FeatureFlag(
+    val key: String,
+) {
+    EXPERIMENTAL_COMPOSE_UI("experimental_compose_ui"),
+    ;
+
+    companion object {
+        fun fromToken(token: String): FeatureFlag? =
+            entries.firstOrNull { flag ->
+                flag.key.equals(token.trim(), ignoreCase = true) ||
+                    flag.name.equals(token.trim(), ignoreCase = true)
+            }
+    }
+}
+
+object FeatureFlags {
+    const val EMPTY = ""
+
+    fun enabledFlags(csv: String): Set<FeatureFlag> =
+        tokens(csv)
+            .mapNotNull(FeatureFlag::fromToken)
+            .toSet()
+
+    fun isEnabled(
+        csv: String,
+        flag: FeatureFlag,
+    ): Boolean = flag in enabledFlags(csv)
+
+    fun setEnabled(
+        csv: String,
+        flag: FeatureFlag,
+        enabled: Boolean,
+    ): String {
+        val enabledFlags = enabledFlags(csv).toMutableSet()
+        if (enabled) {
+            enabledFlags += flag
+        } else {
+            enabledFlags -= flag
+        }
+
+        val knownTokens = FeatureFlag.entries.filter { it in enabledFlags }.map(FeatureFlag::key)
+        val unknownTokens =
+            tokens(csv)
+                .filter { FeatureFlag.fromToken(it) == null }
+                .distinctBy { it.lowercase() }
+
+        return (knownTokens + unknownTokens).joinToString(",")
+    }
+
+    fun migrateLegacyComposeUi(
+        csv: String,
+        legacyEnabled: Boolean,
+        migrationComplete: Boolean,
+    ): String =
+        if (!migrationComplete && legacyEnabled) {
+            setEnabled(
+                csv = csv,
+                flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
+                enabled = true,
+            )
+        } else {
+            csv
+        }
+
+    private fun tokens(csv: String): List<String> =
+        csv
+            .split(',')
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+}

--- a/data/settings/src/test/kotlin/co/anitrend/data/settings/feature/FeatureFlagsTest.kt
+++ b/data/settings/src/test/kotlin/co/anitrend/data/settings/feature/FeatureFlagsTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package co.anitrend.data.settings.feature
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FeatureFlagsTest {
+    @Test
+    fun `given csv with whitespace blanks and duplicates when parsed then known flags are normalized`() {
+        val csv = " experimental_compose_ui, ,EXPERIMENTAL_COMPOSE_UI,unknown "
+
+        val flags = FeatureFlags.enabledFlags(csv)
+
+        assertEquals(setOf(FeatureFlag.EXPERIMENTAL_COMPOSE_UI), flags)
+        assertTrue(FeatureFlags.isEnabled(csv, FeatureFlag.EXPERIMENTAL_COMPOSE_UI))
+    }
+
+    @Test
+    fun `given unknown future flag when enabling known flag then unknown token is preserved`() {
+        val csv = "future_flag"
+
+        val updated = FeatureFlags.setEnabled(csv, FeatureFlag.EXPERIMENTAL_COMPOSE_UI, true)
+
+        assertEquals("experimental_compose_ui,future_flag", updated)
+    }
+
+    @Test
+    fun `given mixed csv when disabling known flag then unknown token remains`() {
+        val csv = "experimental_compose_ui,future_flag"
+
+        val updated = FeatureFlags.setEnabled(csv, FeatureFlag.EXPERIMENTAL_COMPOSE_UI, false)
+
+        assertEquals("future_flag", updated)
+        assertFalse(FeatureFlags.isEnabled(updated, FeatureFlag.EXPERIMENTAL_COMPOSE_UI))
+    }
+
+    @Test
+    fun `given incomplete legacy migration when old compose flag is enabled then csv is enabled without dropping unknown tokens`() {
+        val updated = FeatureFlags.migrateLegacyComposeUi(
+            csv = "future_flag",
+            legacyEnabled = true,
+            migrationComplete = false,
+        )
+
+        assertEquals("experimental_compose_ui,future_flag", updated)
+    }
+
+    @Test
+    fun `given completed legacy migration when old compose flag remains enabled then csv is not re-enabled`() {
+        val updated = FeatureFlags.migrateLegacyComposeUi(
+            csv = FeatureFlags.EMPTY,
+            legacyEnabled = true,
+            migrationComplete = true,
+        )
+
+        assertEquals(FeatureFlags.EMPTY, updated)
+    }
+}

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/compose/PreviewData.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/compose/PreviewData.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.DeveloperBoard
+import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.filled.Refresh
@@ -30,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import co.anitrend.android.core.settings.helper.locale.model.AniTrendLocale
 import co.anitrend.android.core.settings.helper.theme.model.AniTrendTheme
+import co.anitrend.data.settings.feature.FeatureFlag
 import co.anitrend.settings.R
 import co.anitrend.settings.model.SettingItem
 
@@ -161,6 +163,13 @@ internal fun previewDeveloperData(): List<SettingItem> =
             id = "developer_settings_runtime_behavior",
             title = stringResource(R.string.preference_category_title_developer_runtime_behavior),
         ),
+        SettingItem.ClickableSetting(
+            id = "feature_flags",
+            title = stringResource(R.string.preference_title_feature_flags),
+            summary = stringResource(R.string.preference_summary_feature_flags),
+            icon = Icons.Default.Flag,
+            onClick = { },
+        ),
         SettingItem.SwitchSetting(
             id = "clear_on_refresh",
             title = stringResource(R.string.preference_title_refresh_behavior_config),
@@ -175,6 +184,23 @@ internal fun previewDeveloperData(): List<SettingItem> =
             summary = stringResource(R.string.preference_summary_heap),
             icon = Icons.Default.Memory,
             onClick = { true },
+            onValueChange = { },
+        ),
+    )
+
+@Composable
+internal fun previewFeatureFlagData(enabledFlag: FeatureFlag? = null): List<SettingItem> =
+    listOf(
+        SettingItem.CategoryHeader(
+            id = "feature_flags_user_interface",
+            title = stringResource(R.string.preference_category_title_feature_flags_user_interface),
+        ),
+        SettingItem.SwitchSetting(
+            id = FeatureFlag.EXPERIMENTAL_COMPOSE_UI.key,
+            title = stringResource(R.string.preference_title_experimental_compose_ui),
+            summary = stringResource(R.string.preference_summary_experimental_compose_ui),
+            icon = Icons.Default.DeveloperBoard,
+            onClick = { enabledFlag == FeatureFlag.EXPERIMENTAL_COMPOSE_UI },
             onValueChange = { },
         ),
     )

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/compose/SettingsCompose.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/compose/SettingsCompose.kt
@@ -29,6 +29,7 @@ import co.anitrend.navigation.SettingsRouter
 import co.anitrend.settings.component.content.anilist.AniListSettingsScreen
 import co.anitrend.settings.component.content.account.AccountScreen
 import co.anitrend.settings.component.content.developer.DeveloperScreen
+import co.anitrend.settings.component.content.featureflags.FeatureFlagsScreen
 import co.anitrend.settings.component.content.log.LogViewerScreen
 import co.anitrend.settings.component.content.task.TaskScreen
 import co.anitrend.settings.model.SettingItem
@@ -40,6 +41,7 @@ import co.anitrend.settings.component.content.theme.ThemeScreen
 import co.anitrend.settings.component.content.notification.NotificationScreen
 import co.anitrend.settings.component.content.sync.SynchronizationScreen
 import co.anitrend.settings.component.content.storage.StorageScreen
+import co.anitrend.settings.component.presenter.SettingsPresenter
 
 @Composable
 private fun SettingsContent(
@@ -53,7 +55,7 @@ private fun SettingsContent(
 fun SettingsContentScreen(
     navigationController: NavHostController,
     settingsItems: List<SettingItem>,
-    developerSettingsItems: List<SettingItem>,
+    presenter: SettingsPresenter,
     onBackPress: () -> Unit,
 ) {
     DefaultScaffold(onBackPress = onBackPress) { padding ->
@@ -137,7 +139,18 @@ fun SettingsContentScreen(
             composable(
                 route = SettingsRouter.Destination.DEVELOPER.name,
                 content = {
-                    DeveloperScreen(settingsItems = developerSettingsItems)
+                    DeveloperScreen(
+                        presenter = presenter,
+                        navigateTo = {
+                            navigationController.navigate(it.name)
+                        },
+                    )
+                },
+            )
+            composable(
+                route = SettingsRouter.Destination.FEATURE_FLAGS.name,
+                content = {
+                    FeatureFlagsScreen(presenter = presenter)
                 },
             )
             composable(

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/content/developer/DeveloperCompose.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/content/developer/DeveloperCompose.kt
@@ -17,15 +17,132 @@
 package co.anitrend.settings.component.content.developer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import co.anitrend.android.core.ui.AniTrendPreview
 import co.anitrend.android.core.ui.theme.preview.PreviewTheme
-import co.anitrend.settings.component.compose.previewDeveloperData
+import co.anitrend.data.settings.developer.IDeveloperSettings
+import co.anitrend.data.settings.refresh.IRefreshBehaviourSettings
+import co.anitrend.navigation.SettingsRouter
 import co.anitrend.settings.component.compose.SettingsItemsList
+import co.anitrend.settings.component.compose.previewDeveloperData
+import co.anitrend.settings.component.presenter.SettingsPresenter
 import co.anitrend.settings.model.SettingItem
+import org.koin.compose.koinInject
+
+internal data class DeveloperScreenState(
+    val automaticHeapDump: Boolean,
+    val showLeakLauncher: Boolean,
+    val clearDataOnSwipeRefresh: Boolean,
+) {
+    fun asPresenterState() =
+        SettingsPresenter.DeveloperSettingsState(
+            automaticHeapDump = automaticHeapDump,
+            showLeakLauncher = showLeakLauncher,
+            clearDataOnSwipeRefresh = clearDataOnSwipeRefresh,
+        )
+
+    fun updateAutomaticHeapDump(
+        newValue: Boolean,
+        developerSettings: IDeveloperSettings,
+    ): DeveloperScreenState {
+        developerSettings.automaticHeapDump.value = newValue
+        return copy(automaticHeapDump = newValue)
+    }
+
+    fun updateShowLeakLauncher(
+        newValue: Boolean,
+        developerSettings: IDeveloperSettings,
+    ): DeveloperScreenState {
+        developerSettings.showLeakLauncher.value = newValue
+        return copy(showLeakLauncher = newValue)
+    }
+
+    fun updateClearDataOnSwipeRefresh(
+        newValue: Boolean,
+        refreshBehaviourSettings: IRefreshBehaviourSettings,
+    ): DeveloperScreenState {
+        refreshBehaviourSettings.clearDataOnSwipeRefresh.value = newValue
+        return copy(clearDataOnSwipeRefresh = newValue)
+    }
+}
 
 @Composable
 fun DeveloperScreen(
+    modifier: Modifier = Modifier,
+    navigateTo: (SettingsRouter.Destination) -> Unit,
+    presenter: SettingsPresenter = koinInject(),
+    developerSettings: IDeveloperSettings = koinInject(),
+    refreshBehaviourSettings: IRefreshBehaviourSettings = koinInject(),
+) {
+    var state by
+        remember {
+            mutableStateOf(
+                DeveloperScreenState(
+                    automaticHeapDump = developerSettings.automaticHeapDump.value,
+                    showLeakLauncher = developerSettings.showLeakLauncher.value,
+                    clearDataOnSwipeRefresh = refreshBehaviourSettings.clearDataOnSwipeRefresh.value,
+                ),
+            )
+        }
+
+    DeveloperContent(
+        modifier = modifier,
+        settingsItems =
+            presenter
+                .getDeveloperSettingsItems(
+                    state = state.asPresenterState(),
+                    navigateTo = navigateTo,
+                ).withDeveloperScreenState(
+                    state = state,
+                    onStateChange = { state = it },
+                    developerSettings = developerSettings,
+                    refreshBehaviourSettings = refreshBehaviourSettings,
+                ),
+    )
+}
+
+private fun List<SettingItem>.withDeveloperScreenState(
+    state: DeveloperScreenState,
+    onStateChange: (DeveloperScreenState) -> Unit,
+    developerSettings: IDeveloperSettings,
+    refreshBehaviourSettings: IRefreshBehaviourSettings,
+): List<SettingItem> =
+    map { item ->
+        when (item) {
+            is SettingItem.SwitchSetting ->
+                when (item.id) {
+                    "heap_dump" ->
+                        item.copy(
+                            onValueChange = { newValue ->
+                                onStateChange(state.updateAutomaticHeapDump(newValue, developerSettings))
+                            },
+                        )
+                    "show_leak_launcher" ->
+                        item.copy(
+                            onValueChange = { newValue ->
+                                onStateChange(state.updateShowLeakLauncher(newValue, developerSettings))
+                            },
+                        )
+                    "clear_db_on_refresh" ->
+                        item.copy(
+                            onValueChange = { newValue ->
+                                onStateChange(
+                                    state.updateClearDataOnSwipeRefresh(newValue, refreshBehaviourSettings),
+                                )
+                            },
+                        )
+                    else -> item
+                }
+            else -> item
+        }
+    }
+
+@Composable
+private fun DeveloperContent(
     modifier: Modifier = Modifier,
     settingsItems: List<SettingItem>,
 ) {
@@ -38,6 +155,6 @@ fun DeveloperScreen(
 @Composable
 private fun DeveloperScreenPreview() {
     PreviewTheme(wrapInSurface = true) {
-        DeveloperScreen(settingsItems = previewDeveloperData())
+        DeveloperContent(settingsItems = previewDeveloperData())
     }
 }

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsCompose.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsCompose.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package co.anitrend.settings.component.content.featureflags
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import co.anitrend.android.core.ui.AniTrendPreview
+import co.anitrend.android.core.ui.theme.preview.PreviewTheme
+import co.anitrend.data.settings.feature.FeatureFlag
+import co.anitrend.data.settings.feature.FeatureFlags
+import co.anitrend.data.settings.feature.IFeatureFlagSetting
+import co.anitrend.settings.component.compose.SettingsItemsList
+import co.anitrend.settings.component.compose.previewFeatureFlagData
+import co.anitrend.settings.component.presenter.SettingsPresenter
+import co.anitrend.settings.model.SettingItem
+import org.koin.compose.koinInject
+
+internal data class FeatureFlagsScreenState(
+    val featureFlags: String,
+) {
+    fun asPresenterState() = SettingsPresenter.FeatureFlagSettingsState(featureFlags = featureFlags)
+
+    fun updateExperimentalComposeUi(
+        enabled: Boolean,
+        featureFlagSetting: IFeatureFlagSetting,
+    ): FeatureFlagsScreenState {
+        val updatedFlags =
+            FeatureFlags.setEnabled(
+                csv = featureFlags,
+                flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
+                enabled = enabled,
+            )
+        featureFlagSetting.featureFlags.value = updatedFlags
+        return copy(featureFlags = updatedFlags)
+    }
+}
+
+@Composable
+fun FeatureFlagsScreen(
+    modifier: Modifier = Modifier,
+    presenter: SettingsPresenter = koinInject(),
+    featureFlagSetting: IFeatureFlagSetting = koinInject(),
+) {
+    var state by remember { mutableStateOf(FeatureFlagsScreenState(featureFlags = featureFlagSetting.featureFlags.value)) }
+
+    FeatureFlagsContent(
+        modifier = modifier,
+        settingsItems =
+            presenter
+                .getFeatureFlagSettingsItems(
+                    state = state.asPresenterState(),
+                ).withFeatureFlagScreenState(
+                    state = state,
+                    onStateChange = { state = it },
+                    featureFlagSetting = featureFlagSetting,
+                ),
+    )
+}
+
+private fun List<SettingItem>.withFeatureFlagScreenState(
+    state: FeatureFlagsScreenState,
+    onStateChange: (FeatureFlagsScreenState) -> Unit,
+    featureFlagSetting: IFeatureFlagSetting,
+): List<SettingItem> =
+    map { item ->
+        when (item) {
+            is SettingItem.SwitchSetting ->
+                if (item.id == FeatureFlag.EXPERIMENTAL_COMPOSE_UI.key) {
+                    item.copy(
+                        onValueChange = { enabled ->
+                            onStateChange(state.updateExperimentalComposeUi(enabled, featureFlagSetting))
+                        },
+                    )
+                } else {
+                    item
+                }
+            else -> item
+        }
+    }
+
+@Composable
+private fun FeatureFlagsContent(
+    modifier: Modifier = Modifier,
+    settingsItems: List<SettingItem>,
+) {
+    SettingsItemsList(modifier = modifier, settingsItems = settingsItems)
+}
+
+@AniTrendPreview.Light
+@AniTrendPreview.Dark
+@AniTrendPreview.Mobile
+@Composable
+private fun FeatureFlagsScreenPreview() {
+    PreviewTheme(wrapInSurface = true) {
+        FeatureFlagsContent(
+            settingsItems = previewFeatureFlagData(enabledFlag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI),
+        )
+    }
+}

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/presenter/SettingsPresenter.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/presenter/SettingsPresenter.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.BatterySaver
 import androidx.compose.material.icons.outlined.ColorLens
 import androidx.compose.material.icons.outlined.DeveloperBoard
 import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material.icons.outlined.Flag
 import androidx.compose.material.icons.outlined.Interests
 import androidx.compose.material.icons.outlined.LayersClear
 import androidx.compose.material.icons.outlined.Memory
@@ -38,12 +39,14 @@ import co.anitrend.android.core.helpers.notification.hasNotificationPermissionFo
 import co.anitrend.android.core.settings.Settings
 import co.anitrend.android.core.settings.common.locale.ILocaleSettings
 import co.anitrend.android.core.settings.common.theme.IThemeSettings
-import co.anitrend.android.core.settings.helper.locale.model.AniTrendLocale.Companion.asLocale
 import co.anitrend.android.core.settings.helper.locale.model.AniTrendLocale
+import co.anitrend.android.core.settings.helper.locale.model.AniTrendLocale.Companion.asLocale
 import co.anitrend.android.core.settings.helper.theme.model.AniTrendTheme
 import co.anitrend.core.presenter.CorePresenter
 import co.anitrend.data.auth.settings.IAuthenticationSettings
 import co.anitrend.data.settings.cache.ICacheSettings
+import co.anitrend.data.settings.feature.FeatureFlag
+import co.anitrend.data.settings.feature.FeatureFlags
 import co.anitrend.data.settings.notification.INotificationSettings
 import co.anitrend.data.settings.power.IPowerSettings
 import co.anitrend.data.settings.privacy.IPrivacySettings
@@ -63,6 +66,16 @@ class SettingsPresenter(
     settings: Settings,
     private val preferenceBuilder: IPreferenceBuilder,
 ) : CorePresenter(context, settings) {
+    data class DeveloperSettingsState(
+        val automaticHeapDump: Boolean,
+        val showLeakLauncher: Boolean,
+        val clearDataOnSwipeRefresh: Boolean,
+    )
+
+    data class FeatureFlagSettingsState(
+        val featureFlags: String,
+    )
+
     private fun themeLabel(theme: AniTrendTheme): String =
         when (theme) {
             AniTrendTheme.SYSTEM -> context.getString(co.anitrend.android.core.R.string.global_label_system)
@@ -350,7 +363,10 @@ class SettingsPresenter(
         return preferenceBuilder.build()
     }
 
-    fun getDeveloperSettingsItems(navigateTo: (SettingsRouter.Destination) -> Unit): List<SettingItem> {
+    fun getDeveloperSettingsItems(
+        state: DeveloperSettingsState,
+        navigateTo: (SettingsRouter.Destination) -> Unit,
+    ): List<SettingItem> {
         if (!BuildConfig.DEBUG) {
             return listOf(
                 SettingItem.HintCard(
@@ -388,42 +404,66 @@ class SettingsPresenter(
                 id = "developer_settings_runtime_behavior",
                 title = context.getString(co.anitrend.settings.R.string.preference_category_title_developer_runtime_behavior),
             ),
+            SettingItem.ClickableSetting(
+                id = "feature_flags",
+                title = context.getString(co.anitrend.settings.R.string.preference_title_feature_flags),
+                summary = context.getString(co.anitrend.settings.R.string.preference_summary_feature_flags),
+                icon = Icons.Outlined.Flag,
+                currentValue = { context.getString(co.anitrend.settings.R.string.label_settings_state_debug) },
+                onClick = { navigateTo(SettingsRouter.Destination.FEATURE_FLAGS) },
+            ),
             SettingItem.SwitchSetting(
                 id = "heap_dump",
                 title = context.getString(co.anitrend.settings.R.string.preference_title_heap_dump),
                 summary = context.getString(co.anitrend.settings.R.string.preference_summary_heap),
                 icon = Icons.Outlined.Memory,
-                onClick = { settings.automaticHeapDump.value },
+                onClick = { state.automaticHeapDump },
                 onValueChange = { newValue -> settings.automaticHeapDump.value = newValue },
-                enabled = { true },
             ),
             SettingItem.SwitchSetting(
                 id = "show_leak_launcher",
                 title = context.getString(co.anitrend.settings.R.string.preference_title_show_leak_launcher),
                 summary = context.getString(co.anitrend.settings.R.string.preference_summary_show_leak_launcher),
                 icon = Icons.Outlined.DeveloperBoard,
-                onClick = { settings.showLeakLauncher.value },
+                onClick = { state.showLeakLauncher },
                 onValueChange = { newValue -> settings.showLeakLauncher.value = newValue },
-                enabled = { true },
-            ),
-            SettingItem.SwitchSetting(
-                id = "experimental_compose_ui",
-                title = context.getString(co.anitrend.settings.R.string.preference_title_experimental_compose_ui),
-                summary = context.getString(co.anitrend.settings.R.string.preference_summary_experimental_compose_ui),
-                icon = Icons.Outlined.DeveloperBoard,
-                onClick = { settings.experimentalComposeUi.value },
-                onValueChange = { newValue -> settings.experimentalComposeUi.value = newValue },
-                enabled = { true },
             ),
             SettingItem.SwitchSetting(
                 id = "clear_db_on_refresh",
                 title = context.getString(co.anitrend.settings.R.string.preference_title_refresh_behavior_config),
                 summary = context.getString(co.anitrend.settings.R.string.preference_summary_refresh_behavior_config),
                 icon = Icons.Outlined.LayersClear,
-                onClick = { settings.clearDataOnSwipeRefresh.value },
+                onClick = { state.clearDataOnSwipeRefresh },
                 onValueChange = { newValue -> settings.clearDataOnSwipeRefresh.value = newValue },
-                enabled = { true },
             ),
         )
     }
+
+    fun getFeatureFlagSettingsItems(state: FeatureFlagSettingsState): List<SettingItem> =
+        listOf(
+            SettingItem.CategoryHeader(
+                id = "feature_flags_user_interface",
+                title = context.getString(co.anitrend.settings.R.string.preference_category_title_feature_flags_user_interface),
+            ),
+            SettingItem.SwitchSetting(
+                id = FeatureFlag.EXPERIMENTAL_COMPOSE_UI.key,
+                title = context.getString(co.anitrend.settings.R.string.preference_title_experimental_compose_ui),
+                summary = context.getString(co.anitrend.settings.R.string.preference_summary_experimental_compose_ui),
+                icon = Icons.Outlined.DeveloperBoard,
+                onClick = {
+                    FeatureFlags.isEnabled(
+                        csv = state.featureFlags,
+                        flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
+                    )
+                },
+                onValueChange = { newValue ->
+                    settings.featureFlags.value =
+                        FeatureFlags.setEnabled(
+                            csv = settings.featureFlags.value,
+                            flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
+                            enabled = newValue,
+                        )
+                },
+            ),
+        )
 }

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/screen/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/screen/SettingsScreen.kt
@@ -18,9 +18,6 @@ package co.anitrend.settings.component.screen
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.lifecycle.liveData
 import androidx.navigation.compose.rememberNavController
 import co.anitrend.arch.domain.entities.LoadState
@@ -44,28 +41,16 @@ class SettingsScreen : AniTrendScreen() {
                     param = IParam.None,
                 ) {
                     val navController = rememberNavController()
-                    val settingItems by remember {
-                        derivedStateOf {
-                            presenter.getSettingsItems(
-                                navigateTo = {
-                                    navController.navigate(route = it.name)
-                                },
-                            )
-                        }
-                    }
-                    val developerSettingItems by remember {
-                        derivedStateOf {
-                            presenter.getDeveloperSettingsItems(
-                                navigateTo = {
-                                    navController.navigate(route = it.name)
-                                },
-                            )
-                        }
-                    }
+                    val settingItems =
+                        presenter.getSettingsItems(
+                            navigateTo = {
+                                navController.navigate(route = it.name)
+                            },
+                        )
                     SettingsContentScreen(
                         navigationController = navController,
                         settingsItems = settingItems,
-                        developerSettingsItems = developerSettingItems,
+                        presenter = presenter,
                         onBackPress = {
                             if (!navController.popBackStack()) {
                                 onBackPressedDispatcher.onBackPressed()

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="preference_group_title_developer_settings">Developer Settings</string>
     <string name="preference_category_title_developer_diagnostics">Diagnostics</string>
     <string name="preference_category_title_developer_runtime_behavior">Runtime behavior</string>
+    <string name="preference_category_title_feature_flags_user_interface">User interface</string>
 
     <!-- Preference Titles -->
     <string name="preference_title_accounts">Accounts</string>
@@ -50,6 +51,8 @@
     <string name="preference_title_manage_logs">Manage logs</string>
     <!-- Primary diagnostics destination entry for WorkManager overview -->
     <string name="preference_title_work_manager_tasks">Work manager tasks</string>
+    <!-- Developer destination entry for CSV-backed feature flags -->
+    <string name="preference_title_feature_flags">Feature flags</string>
 
     <!-- Preference Summaries -->
     <string name="preference_summary_accounts">Access information about your accounts</string>
@@ -107,6 +110,8 @@
     <string name="preference_summary_manage_logs">Audit application logs</string>
     <!-- Summary for WorkManager task entry in developer settings -->
     <string name="preference_summary_work_manager_tasks">Inspect and manage background tasks</string>
+    <!-- Summary for the developer feature flags destination -->
+    <string name="preference_summary_feature_flags">Opt in to feature-specific experiments</string>
 
     <!-- Title shown when developer settings are opened in non-debug scenarios -->
     <string name="title_settings_developer_unavailable">Developer options unavailable</string>

--- a/feature/settings/src/test/kotlin/co/anitrend/settings/component/content/developer/DeveloperScreenStateTest.kt
+++ b/feature/settings/src/test/kotlin/co/anitrend/settings/component/content/developer/DeveloperScreenStateTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package co.anitrend.settings.component.content.developer
+
+import co.anitrend.arch.extension.settings.BooleanSetting
+import co.anitrend.data.settings.developer.IDeveloperSettings
+import co.anitrend.data.settings.refresh.IRefreshBehaviourSettings
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeveloperScreenStateTest {
+    @Test
+    fun `given developer toggle changes when updating screen state then checked state mirrors immediately`() {
+        val automaticHeapDump = booleanSetting(initial = false)
+        val showLeakLauncher = booleanSetting(initial = false)
+        val clearDataOnSwipeRefresh = booleanSetting(initial = false)
+        val developerSettings =
+            mockk<IDeveloperSettings> {
+                every { this@mockk.automaticHeapDump } returns automaticHeapDump
+                every { this@mockk.showLeakLauncher } returns showLeakLauncher
+            }
+        val refreshBehaviourSettings =
+            mockk<IRefreshBehaviourSettings> {
+                every { this@mockk.clearDataOnSwipeRefresh } returns clearDataOnSwipeRefresh
+            }
+
+        val updatedState =
+            DeveloperScreenState(
+                automaticHeapDump = false,
+                showLeakLauncher = false,
+                clearDataOnSwipeRefresh = false,
+            ).updateAutomaticHeapDump(true, developerSettings)
+                .updateShowLeakLauncher(true, developerSettings)
+                .updateClearDataOnSwipeRefresh(true, refreshBehaviourSettings)
+
+        assertTrue(updatedState.automaticHeapDump)
+        assertTrue(updatedState.showLeakLauncher)
+        assertTrue(updatedState.clearDataOnSwipeRefresh)
+        assertEquals(true, automaticHeapDump.value)
+        assertEquals(true, showLeakLauncher.value)
+        assertEquals(true, clearDataOnSwipeRefresh.value)
+    }
+
+    private fun booleanSetting(initial: Boolean): BooleanSetting {
+        var value = initial
+        return mockk {
+            every { this@mockk.value } answers { value }
+            every { this@mockk.value = any() } answers {
+                value = firstArg()
+                Unit
+            }
+        }
+    }
+}

--- a/feature/settings/src/test/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsScreenStateTest.kt
+++ b/feature/settings/src/test/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsScreenStateTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package co.anitrend.settings.component.content.featureflags
+
+import co.anitrend.arch.extension.settings.StringSetting
+import co.anitrend.data.settings.feature.FeatureFlag
+import co.anitrend.data.settings.feature.FeatureFlags
+import co.anitrend.data.settings.feature.IFeatureFlagSetting
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FeatureFlagsScreenStateTest {
+    @Test
+    fun `given feature flag toggle change when updating screen state then checked state mirrors immediately`() {
+        val featureFlagsSetting = stringSetting(initial = "future_flag")
+        val featureFlagSetting =
+            mockk<IFeatureFlagSetting> {
+                every { this@mockk.featureFlags } returns featureFlagsSetting
+            }
+
+        val updatedState =
+            FeatureFlagsScreenState(featureFlags = featureFlagsSetting.value)
+                .updateExperimentalComposeUi(true, featureFlagSetting)
+
+        assertTrue(
+            FeatureFlags.isEnabled(
+                csv = updatedState.featureFlags,
+                flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
+            ),
+        )
+        assertEquals(updatedState.featureFlags, featureFlagsSetting.value)
+    }
+
+    private fun stringSetting(initial: String): StringSetting {
+        var value = initial
+        return mockk {
+            every { this@mockk.value } answers { value }
+            every { this@mockk.value = any() } answers {
+                value = firstArg()
+                Unit
+            }
+        }
+    }
+}

--- a/feature/settings/src/test/kotlin/co/anitrend/settings/component/presenter/SettingsPresenterDeveloperStateTest.kt
+++ b/feature/settings/src/test/kotlin/co/anitrend/settings/component/presenter/SettingsPresenterDeveloperStateTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 AniTrend
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package co.anitrend.settings.component.presenter
+
+import android.content.Context
+import co.anitrend.android.core.settings.Settings
+import co.anitrend.arch.extension.settings.BooleanSetting
+import co.anitrend.arch.extension.settings.StringSetting
+import co.anitrend.data.settings.feature.FeatureFlag
+import co.anitrend.data.settings.feature.FeatureFlags
+import co.anitrend.navigation.SettingsRouter
+import co.anitrend.settings.component.builder.contract.IPreferenceBuilder
+import co.anitrend.settings.model.SettingItem
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SettingsPresenterDeveloperStateTest {
+    @Test
+    fun `given reactive developer state when creating items then switch checked values reflect provided state`() {
+        val automaticHeapDump = booleanSetting(initial = false)
+        val showLeakLauncher = booleanSetting(initial = false)
+        val clearDataOnSwipeRefresh = booleanSetting(initial = false)
+
+        val presenter =
+            settingsPresenter(
+                automaticHeapDump = automaticHeapDump,
+                showLeakLauncher = showLeakLauncher,
+                clearDataOnSwipeRefresh = clearDataOnSwipeRefresh,
+            )
+
+        val items =
+            presenter.getDeveloperSettingsItems(
+                state =
+                    SettingsPresenter.DeveloperSettingsState(
+                        automaticHeapDump = true,
+                        showLeakLauncher = true,
+                        clearDataOnSwipeRefresh = true,
+                    ),
+                navigateTo = {},
+            )
+
+        val heapDumpToggle = items.switchSetting(id = "heap_dump")
+        val leakLauncherToggle = items.switchSetting(id = "show_leak_launcher")
+        val refreshToggle = items.switchSetting(id = "clear_db_on_refresh")
+
+        assertTrue(heapDumpToggle.onClick())
+        assertTrue(leakLauncherToggle.onClick())
+        assertTrue(refreshToggle.onClick())
+    }
+
+    @Test
+    fun `given developer switch when toggled then underlying settings value updates`() {
+        val automaticHeapDump = booleanSetting(initial = false)
+        val showLeakLauncher = booleanSetting(initial = false)
+        val clearDataOnSwipeRefresh = booleanSetting(initial = false)
+
+        val presenter =
+            settingsPresenter(
+                automaticHeapDump = automaticHeapDump,
+                showLeakLauncher = showLeakLauncher,
+                clearDataOnSwipeRefresh = clearDataOnSwipeRefresh,
+            )
+
+        val items =
+            presenter.getDeveloperSettingsItems(
+                state =
+                    SettingsPresenter.DeveloperSettingsState(
+                        automaticHeapDump = false,
+                        showLeakLauncher = false,
+                        clearDataOnSwipeRefresh = false,
+                    ),
+                navigateTo = {},
+            )
+
+        val heapDumpToggle = items.switchSetting(id = "heap_dump")
+        val leakLauncherToggle = items.switchSetting(id = "show_leak_launcher")
+        val refreshToggle = items.switchSetting(id = "clear_db_on_refresh")
+
+        heapDumpToggle.onValueChange(true)
+        leakLauncherToggle.onValueChange(true)
+        refreshToggle.onValueChange(true)
+
+        assertEquals(true, automaticHeapDump.value)
+        assertEquals(true, showLeakLauncher.value)
+        assertEquals(true, clearDataOnSwipeRefresh.value)
+    }
+
+    @Test
+    fun `given developer feature flags row when clicked then navigates to feature flags destination`() {
+        val presenter = settingsPresenter()
+        var destination: SettingsRouter.Destination? = null
+
+        val items =
+            presenter.getDeveloperSettingsItems(
+                state =
+                    SettingsPresenter.DeveloperSettingsState(
+                        automaticHeapDump = false,
+                        showLeakLauncher = false,
+                        clearDataOnSwipeRefresh = false,
+                    ),
+                navigateTo = { destination = it },
+            )
+
+        items.clickableSetting(id = "feature_flags").onClick()
+
+        assertEquals(SettingsRouter.Destination.FEATURE_FLAGS, destination)
+    }
+
+    @Test
+    fun `given feature flag setting when toggled then csv preference updates without dropping unknown tokens`() {
+        val featureFlags = stringSetting(initial = "future_flag")
+        val presenter = settingsPresenter(featureFlags = featureFlags)
+
+        val items =
+            presenter.getFeatureFlagSettingsItems(
+                state =
+                    SettingsPresenter.FeatureFlagSettingsState(
+                        featureFlags = featureFlags.value,
+                    ),
+            )
+
+        val composeToggle = items.switchSetting(id = FeatureFlag.EXPERIMENTAL_COMPOSE_UI.key)
+        composeToggle.onValueChange(true)
+
+        assertEquals("experimental_compose_ui,future_flag", featureFlags.value)
+    }
+
+    private fun settingsPresenter(
+        automaticHeapDump: BooleanSetting = booleanSetting(initial = false),
+        showLeakLauncher: BooleanSetting = booleanSetting(initial = false),
+        clearDataOnSwipeRefresh: BooleanSetting = booleanSetting(initial = false),
+        featureFlags: StringSetting = stringSetting(initial = FeatureFlags.EMPTY),
+    ): SettingsPresenter {
+        val context = mockk<Context>()
+        every { context.getString(any<Int>()) } answers { firstArg<Int>().toString() }
+        every { context.getString(any<Int>(), *anyVararg()) } answers { firstArg<Int>().toString() }
+
+        val settings = mockk<Settings>()
+        every { settings.automaticHeapDump } returns automaticHeapDump
+        every { settings.showLeakLauncher } returns showLeakLauncher
+        every { settings.clearDataOnSwipeRefresh } returns clearDataOnSwipeRefresh
+        every { settings.featureFlags } returns featureFlags
+
+        return SettingsPresenter(
+            context = context,
+            settings = settings,
+            preferenceBuilder = mockk<IPreferenceBuilder>(relaxed = true),
+        )
+    }
+
+    private fun booleanSetting(initial: Boolean): BooleanSetting {
+        var value = initial
+        return mockk {
+            every { this@mockk.value } answers { value }
+            every { this@mockk.value = any() } answers {
+                value = firstArg()
+                Unit
+            }
+        }
+    }
+
+    private fun stringSetting(initial: String): StringSetting {
+        var value = initial
+        return mockk {
+            every { this@mockk.value } answers { value }
+            every { this@mockk.value = any() } answers {
+                value = firstArg()
+                Unit
+            }
+        }
+    }
+
+    private fun List<SettingItem>.switchSetting(id: String): SettingItem.SwitchSetting =
+        filterIsInstance<SettingItem.SwitchSetting>().first { it.id == id }
+
+    private fun List<SettingItem>.clickableSetting(id: String): SettingItem.ClickableSetting =
+        filterIsInstance<SettingItem.ClickableSetting>().first { it.id == id }
+}


### PR DESCRIPTION
## Description

This fixes stale settings toggle mirroring in the settings module by aligning developer and feature flag screens with the local-state pattern already used by privacy, power, and notification settings.

Changes included in this branch:

- add CSV-backed feature flag settings support and route wiring for the feature flags screen
- update developer and feature flag settings screens to mirror switch state immediately with local Compose screen state while still persisting the backing settings values
- add regression tests for immediate toggle mirroring and presenter-level feature flag behavior
- restore the valid `com.github.anitrend.support-query-builder:core-ext:0.2.13` coordinate so Gradle verification resolves dependencies correctly

## Screenshots:

Not included. This change updates settings behavior and routing; no visual redesign was made.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)

## Verification

- `./gradlew :feature:settings:testDebugUnitTest --no-daemon`
- `./gradlew testDebugUnitTest spotlessCheck --no-daemon`
