### PR TITLE
fix(settings): migrate feature flags to set storage

### DIFF
--- a/android/core/src/main/kotlin/co/anitrend/android/core/settings/Settings.kt
+++ b/android/core/src/main/kotlin/co/anitrend/android/core/settings/Settings.kt
@@ -27,7 +27,7 @@ import co.anitrend.arch.extension.settings.EnumSetting
 import co.anitrend.arch.extension.settings.FloatSetting
 import co.anitrend.arch.extension.settings.IntSetting
 import co.anitrend.arch.extension.settings.LongSetting
-import co.anitrend.arch.extension.settings.StringSetting
+import co.anitrend.arch.extension.settings.SetSetting
 import co.anitrend.data.auth.settings.IAuthenticationSettings
 import co.anitrend.data.auth.settings.IAuthenticationSettings.Companion.INVALID_USER_ID
 import co.anitrend.data.settings.cache.ICacheSettings
@@ -257,37 +257,11 @@ class Settings(
             preference = this,
         )
 
-    override val experimentalComposeUi =
-        BooleanSetting(
-            key = R.string.settings_experimental_compose_ui,
-            default = false,
-            resources = context.resources,
-            preference = this,
-        )
-
     override val featureFlags =
-        StringSetting(
+        SetSetting(
             key = R.string.settings_feature_flags,
             default = FeatureFlags.EMPTY,
             resources = context.resources,
             preference = this,
         )
-
-    private val featureFlagsMigrated =
-        BooleanSetting(
-            key = R.string.settings_feature_flags_migrated,
-            default = false,
-            resources = context.resources,
-            preference = this,
-        )
-
-    init {
-        featureFlags.value =
-            FeatureFlags.migrateLegacyComposeUi(
-                csv = featureFlags.value,
-                legacyEnabled = experimentalComposeUi.value,
-                migrationComplete = featureFlagsMigrated.value,
-            )
-        featureFlagsMigrated.value = true
-    }
 }

--- a/android/core/src/main/res/values/settings.xml
+++ b/android/core/src/main/res/values/settings.xml
@@ -55,5 +55,4 @@
     <string name="settings_show_leak_launcher" translatable="false">_showLeakLauncher</string>
     <string name="settings_experimental_compose_ui" translatable="false">_experimentalComposeUi</string>
     <string name="settings_feature_flags" translatable="false">_featureFlags</string>
-    <string name="settings_feature_flags_migrated" translatable="false">_featureFlagsMigrated</string>
 </resources>

--- a/android/navigation/src/main/kotlin/co/anitrend/android/navigation/drawer/component/content/NavigationDrawerHostFragment.kt
+++ b/android/navigation/src/main/kotlin/co/anitrend/android/navigation/drawer/component/content/NavigationDrawerHostFragment.kt
@@ -49,7 +49,7 @@ class NavigationDrawerHostFragment :
 
     private val useComposeDrawer: Boolean by lazy(LazyThreadSafetyMode.NONE) {
         FeatureFlags.isEnabled(
-            csv = featureFlagSetting.featureFlags.value,
+            flags = featureFlagSetting.featureFlags.value,
             flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
         )
     }

--- a/app/core/src/main/kotlin/co/anitrend/core/migration/model/Migrations.kt
+++ b/app/core/src/main/kotlin/co/anitrend/core/migration/model/Migrations.kt
@@ -21,6 +21,9 @@ import androidx.core.content.edit
 import co.anitrend.android.core.R
 import co.anitrend.android.core.settings.Settings
 import co.anitrend.android.core.storage.StorageController
+import co.anitrend.core.migration.model.Migration
+import co.anitrend.data.settings.feature.FeatureFlag
+import co.anitrend.data.settings.feature.FeatureFlags
 
 internal object Migrations {
     private val FROM_v2_0_0_28_TO_v2_0_0_30 =
@@ -79,6 +82,28 @@ internal object Migrations {
             }
         }
 
+    private val FROM_v2_0_0_41_TO_v2_0_0_42 =
+        object : Migration(2_000_000_041, 2_000_000_042) {
+            override fun invoke(
+                context: Context,
+                settings: Settings,
+            ) {
+                val legacyKey = context.getString(R.string.settings_experimental_compose_ui)
+                val legacyEnabled = settings.contains(legacyKey) && settings.getBoolean(legacyKey, false)
+
+                if (legacyEnabled) {
+                    settings.featureFlags.value =
+                        FeatureFlags.setEnabled(
+                            flags = settings.featureFlags.value,
+                            flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
+                            enabled = true,
+                        )
+                }
+
+                settings.edit(commit = true) { remove(legacyKey) }
+            }
+        }
+
     val ALL =
         listOf(
             FROM_v2_0_0_28_TO_v2_0_0_30,
@@ -86,5 +111,6 @@ internal object Migrations {
             FROM_v2_0_0_32_TO_v2_0_0_33,
             FROM_v2_0_0_33_TO_v2_0_0_39,
             FROM_v2_0_0_39_TO_v2_0_0_41,
+            FROM_v2_0_0_41_TO_v2_0_0_42,
         )
 }

--- a/app/core/src/test/kotlin/co/anitrend/core/migration/MigrationManagerTest.kt
+++ b/app/core/src/test/kotlin/co/anitrend/core/migration/MigrationManagerTest.kt
@@ -17,12 +17,19 @@
 package co.anitrend.core.migration
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import co.anitrend.android.core.R
 import co.anitrend.android.core.settings.Settings
+import co.anitrend.arch.extension.settings.SetSetting
 import co.anitrend.core.migration.model.Migration
+import co.anitrend.core.migration.model.Migrations
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
+import org.junit.jupiter.api.BeforeEach
 
 class MigrationManagerTest {
     private val manager = MigrationManager(mockk())
@@ -98,5 +105,38 @@ class MigrationManagerTest {
             )
 
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `given legacy compose flag when migration runs then feature flag is copied and legacy preference removed`() {
+        val context = mockk<Context>()
+        val settings = mockk<Settings>(relaxed = true)
+        val featureFlags = setSetting(initial = setOf("future_flag"))
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+
+        every { context.getString(R.string.settings_experimental_compose_ui) } returns "_experimentalComposeUi"
+        every { settings.featureFlags } returns featureFlags
+        every { settings.contains("_experimentalComposeUi") } returns true
+        every { settings.getBoolean("_experimentalComposeUi", false) } returns true
+        every { settings.edit() } returns editor
+        every { editor.remove(any()) } returns editor
+        every { editor.commit() } returns true
+
+        Migrations.ALL.last().invoke(context, settings)
+
+        assertEquals(setOf("experimental_compose_ui", "future_flag"), featureFlags.value)
+
+        verify { editor.remove("_experimentalComposeUi") }
+    }
+
+    private fun setSetting(initial: Set<String>): SetSetting {
+        var value = initial
+        return mockk {
+            every { this@mockk.value } answers { value }
+            every { this@mockk.value = any() } answers {
+                value = firstArg()
+                Unit
+            }
+        }
     }
 }

--- a/data/settings/src/main/kotlin/co/anitrend/data/settings/developer/IDeveloperSettings.kt
+++ b/data/settings/src/main/kotlin/co/anitrend/data/settings/developer/IDeveloperSettings.kt
@@ -21,5 +21,4 @@ import co.anitrend.arch.extension.settings.contract.AbstractSetting
 interface IDeveloperSettings {
     val automaticHeapDump: AbstractSetting<Boolean>
     val showLeakLauncher: AbstractSetting<Boolean>
-    val experimentalComposeUi: AbstractSetting<Boolean>
 }

--- a/data/settings/src/main/kotlin/co/anitrend/data/settings/feature/IFeatureFlagSetting.kt
+++ b/data/settings/src/main/kotlin/co/anitrend/data/settings/feature/IFeatureFlagSetting.kt
@@ -19,7 +19,7 @@ package co.anitrend.data.settings.feature
 import co.anitrend.arch.extension.settings.contract.AbstractSetting
 
 interface IFeatureFlagSetting {
-    val featureFlags: AbstractSetting<String>
+    val featureFlags: AbstractSetting<Set<String>>
 }
 
 enum class FeatureFlag(
@@ -38,24 +38,24 @@ enum class FeatureFlag(
 }
 
 object FeatureFlags {
-    const val EMPTY = ""
+    val EMPTY = emptySet<String>()
 
-    fun enabledFlags(csv: String): Set<FeatureFlag> =
-        tokens(csv)
+    fun enabledFlags(flags: Set<String>): Set<FeatureFlag> =
+        tokens(flags)
             .mapNotNull(FeatureFlag::fromToken)
             .toSet()
 
     fun isEnabled(
-        csv: String,
+        flags: Set<String>,
         flag: FeatureFlag,
-    ): Boolean = flag in enabledFlags(csv)
+    ): Boolean = flag in enabledFlags(flags)
 
     fun setEnabled(
-        csv: String,
+        flags: Set<String>,
         flag: FeatureFlag,
         enabled: Boolean,
-    ): String {
-        val enabledFlags = enabledFlags(csv).toMutableSet()
+    ): Set<String> {
+        val enabledFlags = enabledFlags(flags).toMutableSet()
         if (enabled) {
             enabledFlags += flag
         } else {
@@ -64,31 +64,18 @@ object FeatureFlags {
 
         val knownTokens = FeatureFlag.entries.filter { it in enabledFlags }.map(FeatureFlag::key)
         val unknownTokens =
-            tokens(csv)
+            tokens(flags)
                 .filter { FeatureFlag.fromToken(it) == null }
                 .distinctBy { it.lowercase() }
 
-        return (knownTokens + unknownTokens).joinToString(",")
+        return (knownTokens + unknownTokens).toSet()
     }
 
-    fun migrateLegacyComposeUi(
-        csv: String,
-        legacyEnabled: Boolean,
-        migrationComplete: Boolean,
-    ): String =
-        if (!migrationComplete && legacyEnabled) {
-            setEnabled(
-                csv = csv,
-                flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
-                enabled = true,
-            )
-        } else {
-            csv
-        }
-
-    private fun tokens(csv: String): List<String> =
-        csv
-            .split(',')
+    private fun tokens(flags: Set<String>): List<String> =
+        flags
+            .asSequence()
             .map(String::trim)
             .filter(String::isNotEmpty)
+            .distinctBy { it.lowercase() }
+            .toList()
 }

--- a/data/settings/src/test/kotlin/co/anitrend/data/settings/feature/FeatureFlagsTest.kt
+++ b/data/settings/src/test/kotlin/co/anitrend/data/settings/feature/FeatureFlagsTest.kt
@@ -23,53 +23,31 @@ import kotlin.test.assertTrue
 
 class FeatureFlagsTest {
     @Test
-    fun `given csv with whitespace blanks and duplicates when parsed then known flags are normalized`() {
-        val csv = " experimental_compose_ui, ,EXPERIMENTAL_COMPOSE_UI,unknown "
+    fun `given flags with duplicates when parsed then known flags are normalized`() {
+        val flags = setOf(" experimental_compose_ui ", "EXPERIMENTAL_COMPOSE_UI", "unknown")
 
-        val flags = FeatureFlags.enabledFlags(csv)
+        val enabledFlags = FeatureFlags.enabledFlags(flags)
 
-        assertEquals(setOf(FeatureFlag.EXPERIMENTAL_COMPOSE_UI), flags)
-        assertTrue(FeatureFlags.isEnabled(csv, FeatureFlag.EXPERIMENTAL_COMPOSE_UI))
+        assertEquals(setOf(FeatureFlag.EXPERIMENTAL_COMPOSE_UI), enabledFlags)
+        assertTrue(FeatureFlags.isEnabled(flags, FeatureFlag.EXPERIMENTAL_COMPOSE_UI))
     }
 
     @Test
     fun `given unknown future flag when enabling known flag then unknown token is preserved`() {
-        val csv = "future_flag"
+        val flags = setOf("future_flag")
 
-        val updated = FeatureFlags.setEnabled(csv, FeatureFlag.EXPERIMENTAL_COMPOSE_UI, true)
+        val updated = FeatureFlags.setEnabled(flags, FeatureFlag.EXPERIMENTAL_COMPOSE_UI, true)
 
-        assertEquals("experimental_compose_ui,future_flag", updated)
+        assertEquals(setOf("experimental_compose_ui", "future_flag"), updated)
     }
 
     @Test
-    fun `given mixed csv when disabling known flag then unknown token remains`() {
-        val csv = "experimental_compose_ui,future_flag"
+    fun `given mixed flags when disabling known flag then unknown token remains`() {
+        val flags = setOf("experimental_compose_ui", "future_flag")
 
-        val updated = FeatureFlags.setEnabled(csv, FeatureFlag.EXPERIMENTAL_COMPOSE_UI, false)
+        val updated = FeatureFlags.setEnabled(flags, FeatureFlag.EXPERIMENTAL_COMPOSE_UI, false)
 
-        assertEquals("future_flag", updated)
+        assertEquals(setOf("future_flag"), updated)
         assertFalse(FeatureFlags.isEnabled(updated, FeatureFlag.EXPERIMENTAL_COMPOSE_UI))
-    }
-
-    @Test
-    fun `given incomplete legacy migration when old compose flag is enabled then csv is enabled without dropping unknown tokens`() {
-        val updated = FeatureFlags.migrateLegacyComposeUi(
-            csv = "future_flag",
-            legacyEnabled = true,
-            migrationComplete = false,
-        )
-
-        assertEquals("experimental_compose_ui,future_flag", updated)
-    }
-
-    @Test
-    fun `given completed legacy migration when old compose flag remains enabled then csv is not re-enabled`() {
-        val updated = FeatureFlags.migrateLegacyComposeUi(
-            csv = FeatureFlags.EMPTY,
-            legacyEnabled = true,
-            migrationComplete = true,
-        )
-
-        assertEquals(FeatureFlags.EMPTY, updated)
     }
 }

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsCompose.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsCompose.kt
@@ -34,7 +34,7 @@ import co.anitrend.settings.model.SettingItem
 import org.koin.compose.koinInject
 
 internal data class FeatureFlagsScreenState(
-    val featureFlags: String,
+    val featureFlags: Set<String>,
 ) {
     fun asPresenterState() = SettingsPresenter.FeatureFlagSettingsState(featureFlags = featureFlags)
 
@@ -44,7 +44,7 @@ internal data class FeatureFlagsScreenState(
     ): FeatureFlagsScreenState {
         val updatedFlags =
             FeatureFlags.setEnabled(
-                csv = featureFlags,
+                flags = featureFlags,
                 flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
                 enabled = enabled,
             )

--- a/feature/settings/src/main/kotlin/co/anitrend/settings/component/presenter/SettingsPresenter.kt
+++ b/feature/settings/src/main/kotlin/co/anitrend/settings/component/presenter/SettingsPresenter.kt
@@ -73,7 +73,7 @@ class SettingsPresenter(
     )
 
     data class FeatureFlagSettingsState(
-        val featureFlags: String,
+        val featureFlags: Set<String>,
     )
 
     private fun themeLabel(theme: AniTrendTheme): String =
@@ -452,14 +452,14 @@ class SettingsPresenter(
                 icon = Icons.Outlined.DeveloperBoard,
                 onClick = {
                     FeatureFlags.isEnabled(
-                        csv = state.featureFlags,
+                        flags = state.featureFlags,
                         flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
                     )
                 },
                 onValueChange = { newValue ->
                     settings.featureFlags.value =
                         FeatureFlags.setEnabled(
-                            csv = settings.featureFlags.value,
+                            flags = settings.featureFlags.value,
                             flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
                             enabled = newValue,
                         )

--- a/feature/settings/src/test/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsScreenStateTest.kt
+++ b/feature/settings/src/test/kotlin/co/anitrend/settings/component/content/featureflags/FeatureFlagsScreenStateTest.kt
@@ -16,7 +16,7 @@
  */
 package co.anitrend.settings.component.content.featureflags
 
-import co.anitrend.arch.extension.settings.StringSetting
+import co.anitrend.arch.extension.settings.SetSetting
 import co.anitrend.data.settings.feature.FeatureFlag
 import co.anitrend.data.settings.feature.FeatureFlags
 import co.anitrend.data.settings.feature.IFeatureFlagSetting
@@ -29,7 +29,7 @@ import kotlin.test.assertTrue
 class FeatureFlagsScreenStateTest {
     @Test
     fun `given feature flag toggle change when updating screen state then checked state mirrors immediately`() {
-        val featureFlagsSetting = stringSetting(initial = "future_flag")
+        val featureFlagsSetting = setSetting(initial = setOf("future_flag"))
         val featureFlagSetting =
             mockk<IFeatureFlagSetting> {
                 every { this@mockk.featureFlags } returns featureFlagsSetting
@@ -41,14 +41,14 @@ class FeatureFlagsScreenStateTest {
 
         assertTrue(
             FeatureFlags.isEnabled(
-                csv = updatedState.featureFlags,
+                flags = updatedState.featureFlags,
                 flag = FeatureFlag.EXPERIMENTAL_COMPOSE_UI,
             ),
         )
         assertEquals(updatedState.featureFlags, featureFlagsSetting.value)
     }
 
-    private fun stringSetting(initial: String): StringSetting {
+    private fun setSetting(initial: Set<String>): SetSetting {
         var value = initial
         return mockk {
             every { this@mockk.value } answers { value }

--- a/feature/settings/src/test/kotlin/co/anitrend/settings/component/presenter/SettingsPresenterDeveloperStateTest.kt
+++ b/feature/settings/src/test/kotlin/co/anitrend/settings/component/presenter/SettingsPresenterDeveloperStateTest.kt
@@ -19,7 +19,7 @@ package co.anitrend.settings.component.presenter
 import android.content.Context
 import co.anitrend.android.core.settings.Settings
 import co.anitrend.arch.extension.settings.BooleanSetting
-import co.anitrend.arch.extension.settings.StringSetting
+import co.anitrend.arch.extension.settings.SetSetting
 import co.anitrend.data.settings.feature.FeatureFlag
 import co.anitrend.data.settings.feature.FeatureFlags
 import co.anitrend.navigation.SettingsRouter
@@ -124,8 +124,8 @@ class SettingsPresenterDeveloperStateTest {
     }
 
     @Test
-    fun `given feature flag setting when toggled then csv preference updates without dropping unknown tokens`() {
-        val featureFlags = stringSetting(initial = "future_flag")
+    fun `given feature flag setting when toggled then set preference updates without dropping unknown tokens`() {
+        val featureFlags = setSetting(initial = setOf("future_flag"))
         val presenter = settingsPresenter(featureFlags = featureFlags)
 
         val items =
@@ -139,14 +139,14 @@ class SettingsPresenterDeveloperStateTest {
         val composeToggle = items.switchSetting(id = FeatureFlag.EXPERIMENTAL_COMPOSE_UI.key)
         composeToggle.onValueChange(true)
 
-        assertEquals("experimental_compose_ui,future_flag", featureFlags.value)
+        assertEquals(setOf("experimental_compose_ui", "future_flag"), featureFlags.value)
     }
 
     private fun settingsPresenter(
         automaticHeapDump: BooleanSetting = booleanSetting(initial = false),
         showLeakLauncher: BooleanSetting = booleanSetting(initial = false),
         clearDataOnSwipeRefresh: BooleanSetting = booleanSetting(initial = false),
-        featureFlags: StringSetting = stringSetting(initial = FeatureFlags.EMPTY),
+        featureFlags: SetSetting = setSetting(initial = FeatureFlags.EMPTY),
     ): SettingsPresenter {
         val context = mockk<Context>()
         every { context.getString(any<Int>()) } answers { firstArg<Int>().toString() }
@@ -176,7 +176,7 @@ class SettingsPresenterDeveloperStateTest {
         }
     }
 
-    private fun stringSetting(initial: String): StringSetting {
+    private fun setSetting(initial: Set<String>): SetSetting {
         var value = initial
         return mockk {
             every { this@mockk.value } answers { value }


### PR DESCRIPTION
## Summary
- migrate feature flag storage and helpers from CSV strings to `Set<String>`
- move legacy experimental compose flag migration into `MigrationManager` and remove the boot-time settings migration path
- update settings and navigation consumers plus focused unit tests for the new storage shape

## Verification
- `./gradlew :data:settings:testDebugUnitTest --no-daemon`
- `./gradlew :app:core:testDebugUnitTest --no-daemon`
- `./gradlew :feature:settings:testDebugUnitTest --no-daemon`
- `./gradlew :app:core:compileDebugUnitTestKotlin --no-daemon`
