### PR TITLE
ci(graphql): add schema sync automation and contributing conventions

### DIFF
--- a/.github/scripts/sync-graphql-schemas.sh
+++ b/.github/scripts/sync-graphql-schemas.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf 'Usage: sync-graphql-schemas.sh <anilist|anitrend|both>\n' >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+target="$1"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+data_dir="$repo_root/data"
+
+case "$target" in
+  anilist|anitrend|both) ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+if [ "$target" = "anilist" ] || [ "$target" = "both" ]; then
+  npx --yes @graphql-inspector/cli@5.0.7 introspect \
+    https://graphql.anilist.co \
+    --headers '{"user-agent":"JS GraphQL"}' \
+    --write "$data_dir/schema.graphql"
+fi
+
+if [ "$target" = "anitrend" ] || [ "$target" = "both" ]; then
+  npx --yes @graphql-inspector/cli@5.0.7 introspect \
+    https://api.anitrend.co/graphql \
+    --headers '{"User-Agent":"JS GraphQL","Accept":"*/*","Host":"api.anitrend.co"}' \
+    --write "$data_dir/anitrend.schema.graphql"
+fi

--- a/.github/workflows/graphql-schema-sync.yml
+++ b/.github/workflows/graphql-schema-sync.yml
@@ -1,0 +1,103 @@
+name: GraphQL Schema Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Schema target to refresh
+        required: true
+        default: both
+        type: choice
+        options:
+          - anilist
+          - anitrend
+          - both
+  repository_dispatch:
+    types: [graphql-schema-sync]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: graphql-schema-sync
+  cancel-in-progress: false
+
+jobs:
+  sync-schemas:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Normalize target
+        id: target
+        env:
+          DISPATCH_TARGET: ${{ inputs.target }}
+          PAYLOAD_TARGET: ${{ github.event.client_payload.target }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              target="$DISPATCH_TARGET"
+              ;;
+            repository_dispatch)
+              target="$PAYLOAD_TARGET"
+              ;;
+            schedule)
+              target="both"
+              ;;
+            *)
+              printf 'Unsupported event: %s\n' "$EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          case "$target" in
+            anilist|anitrend|both)
+              printf 'target=%s\n' "$target" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              printf 'Invalid target: %s\n' "$target" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Refresh GraphQL schemas
+        run: bash .github/scripts/sync-graphql-schemas.sh "${{ steps.target.outputs.target }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          signoff: true
+          delete-branch: true
+          commit-message: "ci(graphql): refresh GraphQL schemas"
+          title: "ci(graphql): refresh GraphQL schemas"
+          body: |
+            This PR refreshes the tracked GraphQL schema files.
+          branch: ci/update-graphql-schemas
+          base: develop
+          labels: ":skateboard: skip-changelog"
+          add-paths: |
+            data/schema.graphql
+            data/anitrend.schema.graphql

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,33 +10,54 @@ Please ensure your **issues** adheres to the following guidelines:
 
 - Search previous suggestions for duplicates before making a new one.
 - Individual issues for each suggestion, bug or feature.
-- Titles should be [sentence case](http://grammar.yourdictionary.com/capitalization/rules-for-capitalization-in-titles.html)
+- Titles should use a scoped prefix so ownership is visible at a glance, for example `[data] Harden join-table upserts` or `[android:navigation] Align Compose drawer animation`
+- Prefer existing scope families already used in the repository, such as `[data]`, `[feature-media]`, `[testing]`, `[build]`, or `[android:navigation]`
+- Use labels for taxonomy such as feature, bug fix, refactor, or docs rather than encoding taxonomy into the issue title itself
 
 Please ensure your **pull request** adheres to the following guidelines:
 
 - Make an individual pull requests for each issue, and make sure the issue is linked to the PR
-- Titles should be based off of the branch name (e.g. `feat/106-add-new-fancy-feature`)
+- Titles should follow the conventional format `<type>(<scope>): <small summary>` and stay aligned with the branch intent
 - Be sure not to stage any files excluded in any of the `.gitignore` files
 - Assure that your commits mention any relevant **issues** or other **pull requests**
+- Automated pull requests should follow the same branch naming rules as contributor pull requests
 
 
 ## Quality Standards
 
 For any pull requests created exhaustive unit tests are mandatory, showcasing the test cases you've guarded against and the extent of your use case coverage. If you have any questions regarding this please feel free to ask. In addition to these standards please follow the following
 
-- **Branch Naming Convention**: Create branches with the prefix matching the change type, following the format `<type>/<description>` where type is one of:
+- **Branch Naming Convention**: Create branches with the prefix matching the change type, following the format `<type>/<issue>-<short-description>` when an issue already exists. If there is no issue number yet, use `<type>/<short-description>` temporarily and link the branch back to the issue as soon as it exists.
+- Supported branch prefixes should stay aligned with `.github/release-drafter-config.yml`, which drives branch-based auto-labeling and release categorization
+- Current supported primary prefixes are:
   - `feat` - A new feature
   - `fix` - A bug fix
-  - `chore` - Routine tasks (build processes, dependencies)
+  - `chore` - Routine tasks, dependencies, and maintenance
   - `docs` - Documentation only changes
   - `refactor` - Code change that neither fixes a bug nor adds a feature
   - `test` - Adding missing tests or correcting existing tests
   - `build` - Changes that affect the build system or dependencies
-  - `ci` - Changes to CI configuration files
+  - `ci` - Changes to CI configuration files or automation
   - `revert` - Reverting a previous commit
-  - Examples: `feat/add-login-feature`, `fix/bug-in-login`, `chore/update-dependencies`
+- Branch examples:
+  - `feat/1208-anime-themes-source-migration`
+  - `fix/1177-room-ksp-migration-failure`
+  - `docs/1234-update-contributing-guidelines`
+  - `ci/update-graphql-schemas`
+- **Commit Message Convention**: Use the format `<type>(<scope>): <brief summary>` when a clear scope exists. Scope should be a module, package, feature area, or build surface.
+- Commit examples:
+  - `chore(buildSrc): align plugin dependency versions`
+  - `fix(data): guard empty cache writes`
+  - `docs(contributing): clarify branch and PR naming`
+  - `ci(graphql): refresh GraphQL schemas`
+- **Pull Request Title Convention**: Use the format `<type>(<scope>): <small summary>` and keep the title consistent with the branch intent and changed area.
+- Pull request title examples:
+  - `feat(media): add anime themes enrichment`
+  - `refactor(data): standardize module-owned embed mappers`
+  - `ci(graphql): refresh GraphQL schemas`
 - Assign yourself to an issue prior to picking up any work to ensure that multiple people don't start working on the same thing
 - Use [discussions](https://github.com/AniTrend/anitrend-v2/discussions) for general development related queries or planning information to keep our issues clutter free
+- CI-generated maintenance updates should use the same conventions as contributor work. Example branch: `ci/update-graphql-schemas`, example commit: `ci(graphql): refresh GraphQL schemas`
 
 ### Setting up Git Hooks
 

--- a/data/graphql.config.yml
+++ b/data/graphql.config.yml
@@ -17,7 +17,7 @@ extensions:
       headers:
         User-Agent: "JS GraphQL"
         Accept: "*/*"
-        HOST: "api.anitrend.co"
+        Host: "api.anitrend.co"
         Accept-Encoding: "gzip, deflate, br"
         Content-Type: "application/json"
-      introspect: true
+      introspect: false

--- a/data/graphql.config.yml
+++ b/data/graphql.config.yml
@@ -20,4 +20,4 @@ extensions:
         Host: "api.anitrend.co"
         Accept-Encoding: "gzip, deflate, br"
         Content-Type: "application/json"
-      introspect: false
+      introspect: true

--- a/docs/superpowers/plans/2026-05-21-graphql-schema-sync-implementation.md
+++ b/docs/superpowers/plans/2026-05-21-graphql-schema-sync-implementation.md
@@ -1,0 +1,395 @@
+# GraphQL Schema Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace live AniTrend GraphQL introspection with a repo-owned schema sync script and workflow that refreshes `data/schema.graphql` and `data/anitrend.schema.graphql`, while aligning automation naming with the repository contribution conventions.
+
+**Architecture:** Keep the schema generation logic in one parameterized shell script under `.github/scripts/`, and keep the workflow focused on trigger normalization, runtime setup, credentials, and PR creation. Reuse the existing repository automation pattern of app-token checkout plus `peter-evans/create-pull-request`, and remove the temporary `data/package.json`-based tooling in favor of a workflow-local CLI install.
+
+**Tech Stack:** GitHub Actions, shell scripting, Node.js with `@graphql-inspector/cli`, GraphQL schema introspection, repository docs in Markdown.
+
+---
+
+## File Structure
+
+- Modify: `data/graphql.config.yml`
+  - Disable AniTrend live introspection and preserve the correct `Host` header spelling.
+- Create: `.github/scripts/sync-graphql-schemas.sh`
+  - Single entrypoint that accepts `anilist`, `anitrend`, or `both` and writes schema files into `data/`.
+- Modify: `.github/workflows/graphql-schema-sync.yml`
+  - Convert the draft workflow into the final trigger contract for `workflow_dispatch`, `repository_dispatch`, and `schedule`.
+- Delete: `data/package.json`
+  - Remove the temporary local-only CLI wrapper introduced during exploration.
+- Delete: `data/package-lock.json`
+  - Remove the lockfile paired with the temporary package manifest.
+- Modify: `data/schema.graphql`
+  - Refresh generated AniList schema.
+- Modify: `data/anitrend.schema.graphql`
+  - Refresh generated AniTrend schema.
+
+### Task 1: Finalize GraphQL Config And Remove Temporary Tooling
+
+**Files:**
+- Modify: `data/graphql.config.yml:14-23`
+- Delete: `data/package.json`
+- Delete: `data/package-lock.json`
+
+- [ ] **Step 1: Confirm the current config and temporary tooling state**
+
+Run: `git diff -- data/graphql.config.yml data/package.json data/package-lock.json`
+
+Expected: the diff shows the temporary local package tooling and the current AniTrend endpoint block still using `introspect: true` if the draft change has not yet been finalized.
+
+- [ ] **Step 2: Write the minimal config change**
+
+Update the AniTrend endpoint block in `data/graphql.config.yml` so it matches this shape:
+
+```yaml
+    AniTrend:
+      url: https://api.anitrend.co/graphql
+      schema: anitrend.schema.graphql
+      headers:
+        User-Agent: "JS GraphQL"
+        Accept: "*/*"
+        Host: "api.anitrend.co"
+        Accept-Encoding: "gzip, deflate, br"
+        Content-Type: "application/json"
+      introspect: false
+```
+
+Delete `data/package.json` and `data/package-lock.json` entirely once the workflow-local script approach is ready to replace them.
+
+- [ ] **Step 3: Verify the config change and tooling cleanup**
+
+Run: `git diff -- data/graphql.config.yml data/package.json data/package-lock.json`
+
+Expected:
+- `data/graphql.config.yml` shows only the `Host` normalization and `introspect: false` for AniTrend.
+- `data/package.json` and `data/package-lock.json` appear as deletions, not modifications.
+
+- [ ] **Step 4: Commit the config cleanup slice**
+
+```bash
+git add data/graphql.config.yml data/package.json data/package-lock.json
+git commit -m "chore(graphql): remove temporary schema sync package tooling"
+```
+
+### Task 2: Add The Parameterized Schema Sync Script
+
+**Files:**
+- Create: `.github/scripts/sync-graphql-schemas.sh`
+
+- [ ] **Step 1: Write the script file with strict shell behavior and target parsing**
+
+Create `.github/scripts/sync-graphql-schemas.sh` with this structure:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+DATA_DIR="$ROOT_DIR/data"
+TARGET="${1:-}"
+
+case "$TARGET" in
+  anilist|anitrend|both) ;;
+  *)
+    printf 'Usage: %s <anilist|anitrend|both>\n' "${0##*/}" >&2
+    exit 1
+    ;;
+esac
+
+npx --yes @graphql-inspector/cli introspect \
+  https://graphql.anilist.co \
+  --headers '{"user-agent":"JS GraphQL"}' \
+  --write "$DATA_DIR/schema.graphql"
+
+npx --yes @graphql-inspector/cli introspect \
+  https://api.anitrend.co/graphql \
+  --headers '{"User-Agent":"JS GraphQL","Accept":"*/*","Host":"api.anitrend.co"}' \
+  --write "$DATA_DIR/anitrend.schema.graphql"
+```
+
+Do not leave it in this unconditional form. Wrap the AniList call behind `anilist|both` and the AniTrend call behind `anitrend|both`, keeping AniList first when `both` is requested.
+
+- [ ] **Step 2: Make the script executable**
+
+Run: `chmod +x .github/scripts/sync-graphql-schemas.sh`
+
+Expected: no output, file mode updated in git.
+
+- [ ] **Step 3: Verify invalid-input behavior**
+
+Run: `bash .github/scripts/sync-graphql-schemas.sh invalid`
+
+Expected: exit code `1` and output matching `Usage: sync-graphql-schemas.sh <anilist|anitrend|both>`.
+
+- [ ] **Step 4: Execute the narrow-path schema refreshes**
+
+Run each command separately:
+
+```bash
+bash .github/scripts/sync-graphql-schemas.sh anilist
+bash .github/scripts/sync-graphql-schemas.sh anitrend
+```
+
+Expected:
+- first command only updates `data/schema.graphql`
+- second command only updates `data/anitrend.schema.graphql`
+
+- [ ] **Step 5: Execute the combined schema refresh**
+
+Run: `bash .github/scripts/sync-graphql-schemas.sh both`
+
+Expected: both schema files regenerate successfully, with AniList refreshed before AniTrend.
+
+- [ ] **Step 6: Commit the script slice**
+
+```bash
+git add .github/scripts/sync-graphql-schemas.sh data/schema.graphql data/anitrend.schema.graphql
+git commit -m "ci(graphql): add parameterized schema sync script"
+```
+
+### Task 3: Finalize The Workflow Trigger Contract And PR Automation
+
+**Files:**
+- Modify: `.github/workflows/graphql-schema-sync.yml`
+
+- [ ] **Step 1: Replace the draft trigger block with the final contract**
+
+Update the workflow `on:` block to this shape:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Schema target to refresh
+        required: true
+        type: choice
+        options:
+          - anilist
+          - anitrend
+          - both
+        default: both
+  repository_dispatch:
+    types: [graphql-schema-sync]
+  schedule:
+    - cron: '0 6 * * 1'
+```
+
+- [ ] **Step 2: Normalize the target and call the script**
+
+Add a target-resolution step and script execution using this pattern:
+
+```yaml
+      - name: Resolve schema target
+        id: target
+        env:
+          MANUAL_TARGET: ${{ inputs.target }}
+          DISPATCH_TARGET: ${{ github.event.client_payload.target }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TARGET="$MANUAL_TARGET"
+          elif [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            TARGET="$DISPATCH_TARGET"
+          else
+            TARGET="both"
+          fi
+
+          case "$TARGET" in
+            anilist|anitrend|both) ;;
+            *)
+              printf 'Unsupported target: %s\n' "$TARGET" >&2
+              exit 1
+              ;;
+          esac
+
+          printf 'target=%s\n' "$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Run GraphQL schema sync
+        run: bash .github/scripts/sync-graphql-schemas.sh "${{ steps.target.outputs.target }}"
+```
+
+- [ ] **Step 3: Align runtime, token usage, and PR metadata with repo conventions**
+
+Make the workflow follow this metadata shape:
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  sync-schemas:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+```
+
+Update the PR step to use the agreed conventions:
+
+```yaml
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          signoff: true
+          delete-branch: true
+          commit-message: "ci(graphql): refresh GraphQL schemas"
+          title: "ci(graphql): refresh GraphQL schemas"
+          body: |
+            This PR was automatically generated to refresh the tracked GraphQL schema files.
+          branch: ci/update-graphql-schemas
+          base: develop
+          labels: ":skateboard: skip-changelog"
+          add-paths: |
+            data/schema.graphql
+            data/anitrend.schema.graphql
+```
+
+- [ ] **Step 4: Validate the workflow file shape**
+
+Run: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/graphql-schema-sync.yml')"`
+
+Expected: exit code `0` and no YAML parse error.
+
+- [ ] **Step 5: Dry-run the trigger logic mentally against each event**
+
+Verify the workflow covers:
+- `workflow_dispatch` with `target=anilist`
+- `workflow_dispatch` with `target=anitrend`
+- `workflow_dispatch` with `target=both`
+- `repository_dispatch` with `client_payload.target=anilist`
+- `repository_dispatch` with `client_payload.target=anitrend`
+- `repository_dispatch` with `client_payload.target=both`
+- `schedule` defaulting to `both`
+
+The implementation is correct only if invalid `repository_dispatch` input fails rather than silently choosing a partial default.
+
+- [ ] **Step 6: Commit the workflow slice**
+
+```bash
+git add .github/workflows/graphql-schema-sync.yml
+git commit -m "ci(graphql): finalize schema sync workflow contract"
+```
+
+### Task 4: Regenerate Schemas And Verify The Full Integration
+
+**Files:**
+- Modify: `data/schema.graphql`
+- Modify: `data/anitrend.schema.graphql`
+
+- [ ] **Step 1: Run the full schema sync after the workflow and script are in place**
+
+Run: `bash .github/scripts/sync-graphql-schemas.sh both`
+
+Expected: both schema files regenerate successfully with no CLI errors.
+
+- [ ] **Step 2: Verify only the intended files changed**
+
+Run: `git status --short`
+
+Expected: only these project files are changed for the implementation:
+- `data/graphql.config.yml`
+- `.github/scripts/sync-graphql-schemas.sh`
+- `.github/workflows/graphql-schema-sync.yml`
+- `data/schema.graphql`
+- `data/anitrend.schema.graphql`
+- the earlier approved docs already written in this session
+
+No `node_modules/` directory and no replacement package manifests should remain under `data/`.
+
+- [ ] **Step 3: Inspect the final diff for naming consistency**
+
+Run: `git diff -- .github/workflows/graphql-schema-sync.yml .github/scripts/sync-graphql-schemas.sh data/graphql.config.yml CONTRIBUTING.md`
+
+Expected:
+- workflow uses `ci/update-graphql-schemas`
+- commit and PR subject use `ci(graphql): refresh GraphQL schemas`
+- script only accepts `anilist`, `anitrend`, `both`
+- config uses `Host` and `introspect: false` for AniTrend
+
+- [ ] **Step 4: Commit the generated schema refresh**
+
+```bash
+git add data/schema.graphql data/anitrend.schema.graphql
+git commit -m "ci(graphql): refresh tracked schema snapshots"
+```
+
+### Task 5: Final Verification
+
+**Files:**
+- Review: `.github/workflows/graphql-schema-sync.yml`
+- Review: `.github/scripts/sync-graphql-schemas.sh`
+- Review: `data/graphql.config.yml`
+- Review: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Re-run the local script verification matrix**
+
+Run:
+
+```bash
+bash .github/scripts/sync-graphql-schemas.sh anilist
+bash .github/scripts/sync-graphql-schemas.sh anitrend
+bash .github/scripts/sync-graphql-schemas.sh both
+```
+
+Expected: all three commands exit `0`.
+
+- [ ] **Step 2: Verify the workflow can be manually triggered with inputs**
+
+Run:
+
+```bash
+gh workflow run graphql-schema-sync.yml --ref develop -f target=anilist
+gh workflow run graphql-schema-sync.yml --ref develop -f target=anitrend
+gh workflow run graphql-schema-sync.yml --ref develop -f target=both
+```
+
+Expected: all three dispatch commands are accepted by GitHub with no input validation errors.
+
+- [ ] **Step 3: Verify the repository dispatch payload shape is documented and works**
+
+Run this example against the target repository when credentials allow it:
+
+```bash
+gh api \
+  --method POST \
+  repos/AniTrend/anitrend-v2/dispatches \
+  -f event_type='graphql-schema-sync' \
+  -F client_payload[target]='both'
+```
+
+Expected: HTTP `204 No Content`.
+
+- [ ] **Step 4: Review the final working tree before handoff**
+
+Run: `git status --short && git log --oneline -5`
+
+Expected:
+- the intended files are staged or committed as planned
+- recent commits reflect the agreed `chore(...)` and `ci(...)` message structure
+
+- [ ] **Step 5: Prepare handoff notes**
+
+Document these outcomes in the final response:
+- which files were added, removed, and updated
+- the exact workflow trigger contract
+- how to manually dispatch the workflow
+- how another repository should send `repository_dispatch`
+- any verification that could not be completed locally

--- a/docs/superpowers/specs/2026-05-21-graphql-schema-sync-design.md
+++ b/docs/superpowers/specs/2026-05-21-graphql-schema-sync-design.md
@@ -1,0 +1,139 @@
+# GraphQL Schema Sync Design
+
+## Summary
+
+Replace JetBrains live introspection for the AniTrend endpoint with a reliable, repo-owned schema refresh workflow. The workflow refreshes `data/schema.graphql` and `data/anitrend.schema.graphql` on demand, on schedule, or from another repository, then opens or updates a pull request with the generated changes.
+
+## Goals
+
+- Disable live introspection for the AniTrend endpoint in local GraphQL tooling.
+- Refresh GraphQL schema files through automation instead of IDE introspection.
+- Use one workflow contract for manual triggers and cross-repository dispatches.
+- Keep refresh logic in `.github/scripts/` rather than under `data/`.
+- Keep pull request automation aligned with existing repository workflow patterns.
+
+## Non-Goals
+
+- Reorganizing GraphQL assets outside their current `data/` locations.
+- Supporting arbitrary endpoint selection beyond `anilist`, `anitrend`, or `both`.
+- Introducing a reusable workflow unless another repository needs `workflow_call` later.
+
+## Current Constraints
+
+- `data/graphql.config.yml` is the active GraphQL config file.
+- The AniTrend edge schema must remain at `data/anitrend.schema.graphql` because existing docs and tooling already point to that path.
+- Existing GitHub automation in this repository uses app-token checkout and `peter-evans/create-pull-request`.
+- Community guidance already defines branch prefixes in `CONTRIBUTING.md`, so automation should follow the same naming rules.
+
+## Proposed Design
+
+### Configuration
+
+- Set `AniTrend.introspect: false` in `data/graphql.config.yml`.
+- Keep the AniTrend request header name as `Host`, not `HOST`.
+
+### Script
+
+Add one script at `.github/scripts/sync-graphql-schemas.sh`.
+
+Script contract:
+
+- Required positional argument: `anilist`, `anitrend`, or `both`.
+- Invalid input exits non-zero with a short usage message.
+- `anilist` refreshes `data/schema.graphql`.
+- `anitrend` refreshes `data/anitrend.schema.graphql`.
+- `both` refreshes both files in a deterministic order.
+
+Script responsibilities:
+
+- Install or invoke the GraphQL introspection CLI required to fetch schemas.
+- Use the AniTrend headers required by the endpoint:
+  - `User-Agent: JS GraphQL`
+  - `Accept: */*`
+  - `Host: api.anitrend.co`
+- Write generated files directly into `data/`.
+- Fail fast if schema generation fails.
+
+The script owns refresh behavior. The workflow owns trigger handling, credentials, checkout, and PR creation.
+
+### Workflow
+
+Keep one workflow at `.github/workflows/graphql-schema-sync.yml`.
+
+Supported triggers:
+
+- `workflow_dispatch`
+- `repository_dispatch`
+- `schedule`
+
+Trigger contract:
+
+- `workflow_dispatch` exposes an input named `target` with allowed values `anilist`, `anitrend`, `both`.
+- `repository_dispatch` uses event type `graphql-schema-sync` and reads `github.event.client_payload.target` with the same allowed values.
+- `schedule` runs without an external payload and defaults internally to `both`.
+
+Target resolution rules:
+
+- Manual run: use `inputs.target`.
+- Cross-repo dispatch: use `client_payload.target`.
+- Scheduled run: use `both`.
+
+Workflow responsibilities:
+
+- Start with top-level read-only permissions.
+- Grant write permissions only to the job that opens the PR.
+- Mint a short-lived GitHub App token.
+- Check out `develop`.
+- Set up the runtime needed by the schema sync script.
+- Run `.github/scripts/sync-graphql-schemas.sh <target>`.
+- Open or update a single automation PR with `peter-evans/create-pull-request`.
+
+### PR Automation Conventions
+
+Treat this as CI automation.
+
+- Branch: `ci/update-graphql-schemas`
+- Commit message: `ci(graphql): refresh GraphQL schemas`
+- PR title: `ci(graphql): refresh GraphQL schemas`
+
+The repository-wide contribution guide should be the canonical source for branch names, commit subjects, PR titles, and issue title structure. That guide should:
+
+- reference `.github/release-drafter-config.yml` as the source of truth for supported branch-prefix automation
+- document branch naming using the repo's existing `<type>/<issue>-<short-description>` style where an issue number exists
+- document conventional commit and PR title formatting using `<type>(<scope>): <summary>`
+- document issue titles using the existing scoped bracket pattern, such as `[area] Summary` or `[area:subarea] Summary`
+
+The workflow should update one long-lived automation branch and one recurring PR rather than opening a new PR each run.
+
+### Changed Paths in the Automation PR
+
+The PR should include only intended generated files and directly related workflow/config/docs changes:
+
+- `data/schema.graphql`
+- `data/anitrend.schema.graphql`
+- `data/graphql.config.yml` when configuration changes are part of the work
+- `.github/workflows/graphql-schema-sync.yml` when the workflow itself changes
+- `.github/scripts/sync-graphql-schemas.sh` when the sync implementation changes
+- `CONTRIBUTING.md` when community guidance changes
+
+## Error Handling
+
+- Invalid `target` input fails the script before any generation work starts.
+- Missing or malformed `repository_dispatch` payload defaults should not silently refresh the wrong scope; the workflow should either validate the payload or explicitly default only for `schedule`.
+- If one schema refresh fails during `both`, the script should exit non-zero and allow the workflow to fail without opening a misleading PR.
+
+## Testing And Verification
+
+Before adopting the implementation, verify:
+
+- local script execution for `anilist`
+- local script execution for `anitrend`
+- local script execution for `both`
+- manual workflow dispatch for each `target` option
+- repository dispatch using each allowed `target` value
+- scheduled run path defaults to `both`
+- PR branch, commit subject, and changed paths match the documented conventions
+
+## Future Extension
+
+If another repository later needs to reuse this logic through `workflow_call`, extract the orchestration into a reusable workflow and keep this workflow as the thin trigger wrapper. That is intentionally deferred until there is a concrete caller.


### PR DESCRIPTION
## Description

Replace JetBrains live introspection for AniTrend with reliable CLI-based schema syncing and document repo-wide naming conventions.

### Changes

- **data/graphql.config.yml** — Disable AniTrend live introspection (`introspect: false`), fix `Host` header casing
- **.github/scripts/sync-graphql-schemas.sh** — Parameterized script for refreshing `data/schema.graphql` and/or `data/anitrend.schema.graphql` using `@graphql-inspector/cli@5.0.7`
- **.github/workflows/graphql-schema-sync.yml** — Weekly schedule + `workflow_dispatch` + `repository_dispatch` triggers; opens/updates a PR with refreshed schemas via `ci/update-graphql-schemas`
- **CONTRIBUTING.md** — Documented repo-wide branch naming (`<type>/<issue>-<description>`), commit messages (`<type>(<scope>): <summary>`), PR titles, and issue title conventions (`[area] Summary`)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (Improves existing functionality)

<!--- Be kind to code reviewers, and please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [GPL v3 License](https://github.com/AniTrend/anitrend-v2/blob/develop/LICENSE.md).