### PR TITLE
chore(deps): migrate retrofit-graphql from 0.11.13 to 0.12.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,3 +414,5 @@ app/playstore-service-account.json
 docs/specs
 # Added by code-review-graph
 .code-review-graph/
+
+.slim/deepwork/

--- a/buildSrc/src/main/java/co/anitrend/buildSrc/plugins/components/ProjectConfiguration.kt
+++ b/buildSrc/src/main/java/co/anitrend/buildSrc/plugins/components/ProjectConfiguration.kt
@@ -70,7 +70,7 @@ private fun Project.configureLint() = applicationExtension().run {
 internal fun Project.configureAndroid() {
     if (isAppModule()) {
         applicationExtension().apply {
-            compileSdk = 36
+            compileSdk = 37
             defaultConfig {
                 minSdk = 24
                 targetSdk = 36
@@ -157,7 +157,7 @@ internal fun Project.configureAndroid() {
         }
     } else {
         libraryExtension().apply {
-            compileSdk = 36
+            compileSdk = 37
             defaultConfig {
                 minSdk = 24
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/data/android/src/main/kotlin/co/anitrend/data/android/logger/GraphLogger.kt
+++ b/data/android/src/main/kotlin/co/anitrend/data/android/logger/GraphLogger.kt
@@ -16,8 +16,8 @@
  */
 package co.anitrend.data.android.logger
 
-import io.github.wax911.library.logger.contract.ILogger.Level
-import io.github.wax911.library.logger.core.AbstractLogger
+import co.anitrend.retrofit.graphql.logger.contract.ILogger.Level
+import co.anitrend.retrofit.graphql.logger.core.AbstractLogger
 import timber.log.Timber
 
 /**

--- a/data/android/src/main/kotlin/co/anitrend/data/common/model/graph/GraphPayloadExtensions.kt
+++ b/data/android/src/main/kotlin/co/anitrend/data/common/model/graph/GraphPayloadExtensions.kt
@@ -16,7 +16,7 @@
  */
 package co.anitrend.data.common.model.graph
 
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 
 /**
  * Builds a query container from a constrained graph payload contract.

--- a/data/edge/src/main/kotlin/co/anitrend/data/edge/config/datasource/remote/EdgeConfigRemoteSource.kt
+++ b/data/edge/src/main/kotlin/co/anitrend/data/edge/config/datasource/remote/EdgeConfigRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.edge.config.model.remote.EdgeConfigModel
 import co.anitrend.data.edge.core.api.factory.EdgeApiFactory
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/edge/src/main/kotlin/co/anitrend/data/edge/config/source/EdgeConfigSourceImpl.kt
+++ b/data/edge/src/main/kotlin/co/anitrend/data/edge/config/source/EdgeConfigSourceImpl.kt
@@ -28,7 +28,7 @@ import co.anitrend.data.edge.config.datasource.remote.EdgeConfigRemoteSource
 import co.anitrend.data.edge.config.entity.EdgeConfigEntity
 import co.anitrend.data.edge.config.source.contract.EdgeConfigSource
 import co.anitrend.domain.config.entity.Config
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/data/edge/src/main/kotlin/co/anitrend/data/edge/core/api/interceptor/EdgeClientInterceptor.kt
+++ b/data/edge/src/main/kotlin/co/anitrend/data/edge/core/api/interceptor/EdgeClientInterceptor.kt
@@ -16,7 +16,7 @@
  */
 package co.anitrend.data.edge.core.api.interceptor
 
-import io.github.wax911.library.converter.GraphConverter
+import co.anitrend.retrofit.graphql.converter.GraphConverter
 import okhttp3.Interceptor
 import okhttp3.Response
 

--- a/data/edge/src/main/kotlin/co/anitrend/data/edge/media/datasource/remote/EdgeMediaRemoteSource.kt
+++ b/data/edge/src/main/kotlin/co/anitrend/data/edge/media/datasource/remote/EdgeMediaRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.edge.core.api.factory.EdgeApiFactory
 import co.anitrend.data.edge.media.model.remote.EdgeMediaModel
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/edge/src/main/kotlin/co/anitrend/data/edge/news/datasource/remote/EdgeNewsRemoteSource.kt
+++ b/data/edge/src/main/kotlin/co/anitrend/data/edge/news/datasource/remote/EdgeNewsRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.edge.core.api.factory.EdgeApiFactory
 import co.anitrend.data.edge.news.model.remote.EdgeNewsConnectionModel
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/airing/datasource/remote/AiringRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/airing/datasource/remote/AiringRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.airing.model.container.AiringScheduleModelContainer
 import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/android/koin/Modules.kt
+++ b/data/src/main/kotlin/co/anitrend/data/android/koin/Modules.kt
@@ -71,10 +71,10 @@ import com.chuckerteam.chucker.api.RetentionManager
 import com.google.gson.GsonBuilder
 import com.google.gson.Strictness
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
-import io.github.wax911.library.annotation.processor.GraphProcessor
-import io.github.wax911.library.annotation.processor.contract.AbstractGraphProcessor
-import io.github.wax911.library.annotation.processor.plugin.AssetManagerDiscoveryPlugin
-import io.github.wax911.library.logger.contract.ILogger
+import co.anitrend.retrofit.graphql.annotation.processor.GraphProcessor
+import co.anitrend.retrofit.graphql.annotation.processor.contract.AbstractGraphProcessor
+import co.anitrend.retrofit.graphql.annotation.processor.plugin.AssetManagerDiscoveryPlugin
+import co.anitrend.retrofit.graphql.logger.contract.ILogger
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic

--- a/data/src/main/kotlin/co/anitrend/data/auth/datasource/remote/AuthRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/auth/datasource/remote/AuthRemoteSource.kt
@@ -22,8 +22,8 @@ import co.anitrend.data.core.JSON
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.user.model.container.UserModelContainer
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Field

--- a/data/src/main/kotlin/co/anitrend/data/auth/source/AuthSourceImpl.kt
+++ b/data/src/main/kotlin/co/anitrend/data/auth/source/AuthSourceImpl.kt
@@ -32,7 +32,7 @@ import co.anitrend.data.user.converter.UserEntityConverter
 import co.anitrend.data.user.datasource.local.UserLocalSource
 import co.anitrend.data.user.entity.UserEntity
 import co.anitrend.domain.account.model.AccountParam
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect

--- a/data/src/main/kotlin/co/anitrend/data/carousel/datasource/remote/CarouselRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/carousel/datasource/remote/CarouselRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.carousel.model.CarouselModel
 import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/character/datasource/remote/CharacterRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/character/datasource/remote/CharacterRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.character.model.container.CharacterContainer
 import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/core/api/converter/AniTrendConverterFactory.kt
+++ b/data/src/main/kotlin/co/anitrend/data/core/api/converter/AniTrendConverterFactory.kt
@@ -21,8 +21,8 @@ import co.anitrend.data.core.JSON
 import co.anitrend.data.core.XML
 import co.anitrend.data.core.api.converter.request.AniRequestConverter
 import com.google.gson.Gson
-import io.github.wax911.library.annotation.processor.contract.AbstractGraphProcessor
-import io.github.wax911.library.converter.GraphConverter
+import co.anitrend.retrofit.graphql.annotation.processor.contract.AbstractGraphProcessor
+import co.anitrend.retrofit.graphql.converter.GraphConverter
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Converter

--- a/data/src/main/kotlin/co/anitrend/data/core/api/converter/request/AniGraphRequestConverter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/core/api/converter/request/AniGraphRequestConverter.kt
@@ -20,12 +20,9 @@ import co.anitrend.data.BuildConfig
 import co.anitrend.data.core.AniTrendExperimentalFeature
 import co.anitrend.data.util.GraphUtil.minify
 import com.google.gson.Gson
-import io.github.wax911.library.annotation.processor.contract.AbstractGraphProcessor
-import io.github.wax911.library.converter.request.GraphRequestConverter
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.processor.contract.AbstractGraphProcessor
+import co.anitrend.retrofit.graphql.converter.request.GraphRequestConverter
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 
 internal class AniRequestConverter(
     methodAnnotations: Array<out Annotation>,
@@ -33,22 +30,18 @@ internal class AniRequestConverter(
     gson: Gson,
 ) : GraphRequestConverter(methodAnnotations, processor, gson) {
     /**
-     * Converter for the request body, gets the GraphQL query from the method annotation
-     * and constructs a GraphQL request body to send over the network.
+     * Resolves the raw GraphQL query string from the method annotations,
+     * applying minification in release builds for smaller payloads.
      *
-     * @param containerBuilder The constructed builder method of your query with variables
+     * @return The resolved query string, or null if no query is found.
+     * @see GraphRequestConverter.resolveQuery
      */
     @OptIn(AniTrendExperimentalFeature::class)
-    override fun convert(containerBuilder: QueryContainerBuilder): RequestBody {
+    override fun resolveQuery(): String? {
         // we need structured line numbers if we're in the debug env otherwise we can minify queries
-        val query = graphProcessor.getQuery(methodAnnotations)?.minify(!BuildConfig.DEBUG)
-        val queryContainer =
-            containerBuilder
-                .setQuery(query)
-                .build()
-
-        val queryJson = gson.toJson(queryContainer)
-        return queryJson.toRequestBody(JSON_MIME_TYPE)
+        return graphProcessor
+            .getQuery(methodAnnotations)
+            ?.minify(!BuildConfig.DEBUG)
     }
 
     companion object {

--- a/data/src/main/kotlin/co/anitrend/data/core/api/interceptor/GraphClientInterceptor.kt
+++ b/data/src/main/kotlin/co/anitrend/data/core/api/interceptor/GraphClientInterceptor.kt
@@ -17,7 +17,7 @@
 package co.anitrend.data.core.api.interceptor
 
 import co.anitrend.data.auth.helper.contract.IAuthenticationHelper
-import io.github.wax911.library.converter.GraphConverter
+import co.anitrend.retrofit.graphql.converter.GraphConverter
 import okhttp3.Interceptor
 import okhttp3.Response
 

--- a/data/src/main/kotlin/co/anitrend/data/favourite/datasource/remote/FavouriteRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/favourite/datasource/remote/FavouriteRemoteSource.kt
@@ -18,8 +18,8 @@ package co.anitrend.data.favourite.datasource.remote
 
 import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.model.GraphQLResponse
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/genre/datasource/remote/MediaGenreRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/genre/datasource/remote/MediaGenreRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.genre.model.GenreCollection
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/genre/source/GenreSourceImpl.kt
+++ b/data/src/main/kotlin/co/anitrend/data/genre/source/GenreSourceImpl.kt
@@ -28,7 +28,7 @@ import co.anitrend.data.genre.datasource.remote.MediaGenreRemoteSource
 import co.anitrend.data.genre.entity.filter.GenreQueryFilter
 import co.anitrend.data.genre.source.contract.GenreSource
 import co.anitrend.domain.genre.entity.Genre
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn

--- a/data/src/main/kotlin/co/anitrend/data/media/datasource/remote/MediaRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/media/datasource/remote/MediaRemoteSource.kt
@@ -23,8 +23,8 @@ import co.anitrend.data.media.model.container.MediaConnectionModelContainer
 import co.anitrend.data.media.model.container.MediaModelContainer
 import co.anitrend.data.media.model.container.MediaSidecarModelContainer
 import co.anitrend.data.media.model.container.MediaPeopleModelContainer
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/medialist/datasource/remote/MediaListRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/medialist/datasource/remote/MediaListRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.medialist.model.container.MediaListContainerModel
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/recommendation/datasource/remote/RecommendationRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/recommendation/datasource/remote/RecommendationRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.recommendation.model.container.RecommendationModelContainer
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/review/datasource/remote/ReviewRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/review/datasource/remote/ReviewRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.review.model.container.ReviewContainerModel
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/staff/datasource/remote/StaffRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/staff/datasource/remote/StaffRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.staff.model.container.StaffModelContainer
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/studio/datasource/remote/StudioRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/studio/datasource/remote/StudioRemoteSource.kt
@@ -21,8 +21,8 @@ import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.studio.model.remote.StudioDetailContainer
 import co.anitrend.data.studio.model.remote.StudioPagedContainer
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/studio/source/StudioDetailSourceImpl.kt
+++ b/data/src/main/kotlin/co/anitrend/data/studio/source/StudioDetailSourceImpl.kt
@@ -34,7 +34,7 @@ import co.anitrend.domain.media.entity.MediaStudioEntry
 import co.anitrend.domain.media.enums.MediaFormat
 import co.anitrend.domain.medialist.enums.ScoreFormat
 import co.anitrend.domain.studio.entity.StudioDetailData
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine

--- a/data/src/main/kotlin/co/anitrend/data/tag/datasource/remote/MediaTagRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/tag/datasource/remote/MediaTagRemoteSource.kt
@@ -20,8 +20,8 @@ import co.anitrend.data.core.GRAPHQL
 import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.tag.model.remote.TagContainerModel
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/tag/source/TagSourceImpl.kt
+++ b/data/src/main/kotlin/co/anitrend/data/tag/source/TagSourceImpl.kt
@@ -28,7 +28,7 @@ import co.anitrend.data.tag.datasource.remote.MediaTagRemoteSource
 import co.anitrend.data.tag.entity.filter.TagQueryFilter
 import co.anitrend.data.tag.source.contract.TagSource
 import co.anitrend.domain.tag.entity.Tag
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn

--- a/data/src/main/kotlin/co/anitrend/data/user/datasource/remote/UserRemoteSource.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/datasource/remote/UserRemoteSource.kt
@@ -21,8 +21,8 @@ import co.anitrend.data.core.api.factory.contract.IEndpointType
 import co.anitrend.data.core.api.model.GraphQLResponse
 import co.anitrend.data.user.model.container.UserModelContainer
 import co.anitrend.data.user.model.container.UserSidecarModelContainer
-import io.github.wax911.library.annotation.GraphQuery
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.GraphQuery
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/data/src/main/kotlin/co/anitrend/data/util/GraphUtil.kt
+++ b/data/src/main/kotlin/co/anitrend/data/util/GraphUtil.kt
@@ -22,7 +22,7 @@ import co.anitrend.data.common.model.graph.IGraphPayload
 import co.anitrend.data.core.AniTrendExperimentalFeature
 import co.anitrend.domain.common.sort.contract.ISortWithOrder
 import co.anitrend.domain.common.sort.order.SortOrder
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 
 /**
  * Graph request helper class

--- a/data/src/test/kotlin/co/anitrend/data/core/api/converter/request/AniGraphRequestConverterTest.kt
+++ b/data/src/test/kotlin/co/anitrend/data/core/api/converter/request/AniGraphRequestConverterTest.kt
@@ -1,8 +1,8 @@
 package co.anitrend.data.core.api.converter.request
 
 import com.google.gson.Gson
-import io.github.wax911.library.annotation.processor.contract.AbstractGraphProcessor
-import io.github.wax911.library.model.request.QueryContainerBuilder
+import co.anitrend.retrofit.graphql.annotation.processor.contract.AbstractGraphProcessor
+import co.anitrend.retrofit.graphql.model.request.QueryContainerBuilder
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ androidx-work = "2.11.2"
 anitrend-arch = "1.9.2"
 anitrend-emojify = "2.2.0"
 anitrend-markdown = "0.12.1-alpha01"
-anitrend-retrofit = "0.11.13"
+anitrend-retrofit = "0.12.2"
 anitrend-querybuilder = "0.3.3"
 
 chuncker = "4.3.1"


### PR DESCRIPTION
## Summary

Migrates the retrofit-graphql library from the monolithic `:library` v0.11.13 to the modular v0.12.2.

## Changes

- **Version bump**: `com.github.anitrend:retrofit-graphql` 0.11.13 → 0.12.2
- **compileSdk**: 36 → 37 (required by v0.12.2)
- **Namespace migration**: `io.github.wax911.library` → `co.anitrend.retrofit.graphql` across 56 imports in 32 files
  - Edge canary first (`:data:edge`, 5 files), then remaining `:data` + `:data:android` modules
- **API adaptation**: `AniGraphRequestConverter` — override `resolveQuery()` instead of `convert()` to inject query minification at a single override point (parent handles serialization)
- **No codegen adoption**: Asset-based query discovery retained; build-time codegen deferred to follow-up

## Verification

- `spotlessApply`: BUILD SUCCESSFUL (460 tasks)
- `testDebugUnitTest`: BUILD SUCCESSFUL (144 tests, 0 failures)
- Zero `io.github.wax911.library` imports remaining