### PR TITLE
fix(data): add missing Room FK indices and resolve compiler warnings

### DIFF
--- a/data/schemas/co.anitrend.data.android.database.AniTrendStore/24.json
+++ b/data/schemas/co.anitrend.data.android.database.AniTrendStore/24.json
@@ -1,0 +1,6536 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "edcee7bec3449c0c770cde56e6523126",
+    "entities": [
+      {
+        "tableName": "cache_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `request` TEXT NOT NULL, `cache_item_id` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "request",
+            "columnName": "request",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheItemId",
+            "columnName": "cache_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cache_log_cache_item_id",
+            "unique": false,
+            "columnNames": [
+              "cache_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cache_log_cache_item_id` ON `${TABLE_NAME}` (`cache_item_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "auth",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `user_id` INTEGER NOT NULL, `expires_on` INTEGER NOT NULL, `token_type` TEXT NOT NULL, `access_token` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresOn",
+            "columnName": "expires_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenType",
+            "columnName": "token_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "access_token",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_auth_access_token",
+            "unique": true,
+            "columnNames": [
+              "access_token"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_auth_access_token` ON `${TABLE_NAME}` (`access_token`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `description` TEXT, `category` TEXT, `is_general_spoiler` INTEGER NOT NULL, `is_adult` INTEGER NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isGeneralSpoiler",
+            "columnName": "is_general_spoiler",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAdult",
+            "columnName": "is_adult",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tag_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tag_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_tag_category",
+            "unique": false,
+            "columnNames": [
+              "category"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tag_category` ON `${TABLE_NAME}` (`category`)"
+          }
+        ]
+      },
+      {
+        "tableName": "tag_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rank` INTEGER NOT NULL, `is_media_spoiler` INTEGER NOT NULL, `media_id` INTEGER NOT NULL, `tag_id` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, FOREIGN KEY(`tag_id`) REFERENCES `tag`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMediaSpoiler",
+            "columnName": "is_media_spoiler",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tag_connection_tag_id_media_id",
+            "unique": true,
+            "columnNames": [
+              "tag_id",
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tag_connection_tag_id_media_id` ON `${TABLE_NAME}` (`tag_id`, `media_id`)"
+          },
+          {
+            "name": "index_tag_connection_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tag_connection_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          },
+          {
+            "name": "index_tag_connection_tag_id",
+            "unique": false,
+            "columnNames": [
+              "tag_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tag_connection_tag_id` ON `${TABLE_NAME}` (`tag_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tag",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tag_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "genre",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `genre` TEXT NOT NULL, `emoji` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_genre_genre_emoji",
+            "unique": true,
+            "columnNames": [
+              "genre",
+              "emoji"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_genre_genre_emoji` ON `${TABLE_NAME}` (`genre`, `emoji`)"
+          }
+        ]
+      },
+      {
+        "tableName": "genre_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `genre_id` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`genre_id`) REFERENCES `genre`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreId",
+            "columnName": "genre_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_genre_connection_genre_id_media_id",
+            "unique": true,
+            "columnNames": [
+              "genre_id",
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_genre_connection_genre_id_media_id` ON `${TABLE_NAME}` (`genre_id`, `media_id`)"
+          },
+          {
+            "name": "index_genre_connection_genre_id",
+            "unique": false,
+            "columnNames": [
+              "genre_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_genre_connection_genre_id` ON `${TABLE_NAME}` (`genre_id`)"
+          },
+          {
+            "name": "index_genre_connection_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_genre_connection_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "genre",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "genre_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`next_airing_id` INTEGER, `average_score` INTEGER, `chapters` INTEGER, `country_of_origin` TEXT, `description` TEXT, `duration` INTEGER, `end_date` TEXT, `episodes` INTEGER, `favourites` INTEGER NOT NULL, `media_format` TEXT, `hash_tag` TEXT, `is_adult` INTEGER, `is_favourite` INTEGER NOT NULL, `is_favourite_blocked` INTEGER NOT NULL, `is_licensed` INTEGER, `is_recommendation_blocked` INTEGER NOT NULL, `is_review_blocked` INTEGER NOT NULL, `is_locked` INTEGER, `mean_score` INTEGER, `popularity` INTEGER, `season` TEXT, `site_url` TEXT, `source` TEXT, `start_date` TEXT, `status` TEXT, `synonyms` TEXT NOT NULL, `trending` INTEGER, `media_type` TEXT NOT NULL, `updated_at` INTEGER, `volumes` INTEGER, `mal_id` INTEGER, `id` INTEGER NOT NULL, `cover_color` TEXT, `cover_extra_large` TEXT, `cover_large` TEXT, `cover_medium` TEXT, `cover_banner` TEXT, `title_romaji` TEXT, `title_english` TEXT, `title_original` TEXT, `title_user_preferred` TEXT, `trailer_id` TEXT, `trailer_site` TEXT, `trailer_thumbnail` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "nextAiringId",
+            "columnName": "next_airing_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "averageScore",
+            "columnName": "average_score",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "countryOfOrigin",
+            "columnName": "country_of_origin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "end_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodes",
+            "columnName": "episodes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "favourites",
+            "columnName": "favourites",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "media_format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hashTag",
+            "columnName": "hash_tag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAdult",
+            "columnName": "is_adult",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "is_favourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavouriteBlocked",
+            "columnName": "is_favourite_blocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLicensed",
+            "columnName": "is_licensed",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isRecommendationBlocked",
+            "columnName": "is_recommendation_blocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isReviewBlocked",
+            "columnName": "is_review_blocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLocked",
+            "columnName": "is_locked",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "popularity",
+            "columnName": "popularity",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "start_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "synonyms",
+            "columnName": "synonyms",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trending",
+            "columnName": "trending",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumes",
+            "columnName": "volumes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "malId",
+            "columnName": "mal_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverImage.color",
+            "columnName": "cover_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.extraLarge",
+            "columnName": "cover_extra_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.large",
+            "columnName": "cover_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.medium",
+            "columnName": "cover_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.banner",
+            "columnName": "cover_banner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.romaji",
+            "columnName": "title_romaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.english",
+            "columnName": "title_english",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.original",
+            "columnName": "title_original",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.userPreferred",
+            "columnName": "title_user_preferred",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trailer.id",
+            "columnName": "trailer_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trailer.site",
+            "columnName": "trailer_site",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trailer.thumbnail",
+            "columnName": "trailer_thumbnail",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_mal_id",
+            "unique": true,
+            "columnNames": [
+              "mal_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_mal_id` ON `${TABLE_NAME}` (`mal_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title_romaji` TEXT NOT NULL, `title_english` TEXT NOT NULL, `title_original` TEXT NOT NULL, content=`media`)",
+        "fields": [
+          {
+            "fieldPath": "romaji",
+            "columnName": "title_romaji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "english",
+            "columnName": "title_english",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "original",
+            "columnName": "title_original",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "media",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_media_fts_BEFORE_UPDATE BEFORE UPDATE ON `media` BEGIN DELETE FROM `media_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_media_fts_BEFORE_DELETE BEFORE DELETE ON `media` BEGIN DELETE FROM `media_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_media_fts_AFTER_UPDATE AFTER UPDATE ON `media` BEGIN INSERT INTO `media_fts`(`docid`, `title_romaji`, `title_english`, `title_original`) VALUES (NEW.`rowid`, NEW.`title_romaji`, NEW.`title_english`, NEW.`title_original`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_media_fts_AFTER_INSERT AFTER INSERT ON `media` BEGIN INSERT INTO `media_fts`(`docid`, `title_romaji`, `title_english`, `title_original`) VALUES (NEW.`rowid`, NEW.`title_romaji`, NEW.`title_english`, NEW.`title_original`); END"
+        ]
+      },
+      {
+        "tableName": "airing_schedule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`airing_at` INTEGER NOT NULL, `episode` INTEGER NOT NULL, `media_id` INTEGER NOT NULL, `time_until_airing` INTEGER NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "airingAt",
+            "columnName": "airing_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode",
+            "columnName": "episode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeUntilAiring",
+            "columnName": "time_until_airing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_airing_schedule_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_airing_schedule_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`updated_at` INTEGER, `created_at` INTEGER, `id` INTEGER NOT NULL, `user_name` TEXT NOT NULL, `user_bio` TEXT, `user_site_url` TEXT NOT NULL, `user_donator_tier` INTEGER, `user_donator_badge` TEXT, `user_is_following` INTEGER, `user_is_follower` INTEGER, `user_is_blocked` INTEGER, `cover_large` TEXT, `cover_medium` TEXT, `cover_banner` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "about.name",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "about.bio",
+            "columnName": "user_bio",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "about.siteUrl",
+            "columnName": "user_site_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "about.donatorTier",
+            "columnName": "user_donator_tier",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "about.donatorBadge",
+            "columnName": "user_donator_badge",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status.isFollowing",
+            "columnName": "user_is_following",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status.isFollower",
+            "columnName": "user_is_follower",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "status.isBlocked",
+            "columnName": "user_is_blocked",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverImage.large",
+            "columnName": "cover_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.medium",
+            "columnName": "cover_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.banner",
+            "columnName": "cover_banner",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_user_name",
+            "unique": true,
+            "columnNames": [
+              "user_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_user_name` ON `${TABLE_NAME}` (`user_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`user_name` TEXT NOT NULL, content=`user`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "user",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_user_fts_BEFORE_UPDATE BEFORE UPDATE ON `user` BEGIN DELETE FROM `user_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_user_fts_BEFORE_DELETE BEFORE DELETE ON `user` BEGIN DELETE FROM `user_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_user_fts_AFTER_UPDATE AFTER UPDATE ON `user` BEGIN INSERT INTO `user_fts`(`docid`, `user_name`) VALUES (NEW.`rowid`, NEW.`user_name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_user_fts_AFTER_INSERT AFTER INSERT ON `user` BEGIN INSERT INTO `user_fts`(`docid`, `user_name`) VALUES (NEW.`rowid`, NEW.`user_name`); END"
+        ]
+      },
+      {
+        "tableName": "user_general_option",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `airing_notifications` INTEGER NOT NULL, `display_adult_content` INTEGER NOT NULL, `notification_option` TEXT NOT NULL, `title_language` TEXT NOT NULL, `profile_color` TEXT, `time_zone` TEXT, `staff_name_language` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "airingNotifications",
+            "columnName": "airing_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayAdultContent",
+            "columnName": "display_adult_content",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationOption",
+            "columnName": "notification_option",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleLanguage",
+            "columnName": "title_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileColor",
+            "columnName": "profile_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timeZone",
+            "columnName": "time_zone",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "staffNameLanguage",
+            "columnName": "staff_name_language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_general_option_user_id",
+            "unique": true,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_general_option_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_media_option",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `score_format` TEXT NOT NULL, `list_row_order` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `anime_custom_lists` TEXT NOT NULL, `anime_section_order` TEXT NOT NULL, `anime_advanced_scoring` TEXT NOT NULL, `anime_advanced_scoring_enabled` INTEGER NOT NULL, `anime_split_completed_section_by_format` INTEGER NOT NULL, `manga_custom_lists` TEXT NOT NULL, `manga_section_order` TEXT NOT NULL, `manga_advanced_scoring` TEXT NOT NULL, `manga_advanced_scoring_enabled` INTEGER NOT NULL, `manga_split_completed_section_by_format` INTEGER NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scoreFormat",
+            "columnName": "score_format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowOrder",
+            "columnName": "list_row_order",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anime.customLists",
+            "columnName": "anime_custom_lists",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anime.sectionOrder",
+            "columnName": "anime_section_order",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anime.advancedScoring",
+            "columnName": "anime_advanced_scoring",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anime.advancedScoringEnabled",
+            "columnName": "anime_advanced_scoring_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anime.splitCompletedSectionByFormat",
+            "columnName": "anime_split_completed_section_by_format",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manga.customLists",
+            "columnName": "manga_custom_lists",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manga.sectionOrder",
+            "columnName": "manga_section_order",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manga.advancedScoring",
+            "columnName": "manga_advanced_scoring",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manga.advancedScoringEnabled",
+            "columnName": "manga_advanced_scoring_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manga.splitCompletedSectionByFormat",
+            "columnName": "manga_split_completed_section_by_format",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_media_option_user_id",
+            "unique": true,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_media_option_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `id` INTEGER NOT NULL, `statistic_anime_count` INTEGER, `statistic_anime_mean_score` REAL, `statistic_anime_standard_deviation` REAL, `statistic_anime_minutes_watched` INTEGER, `statistic_anime_episodes_watched` INTEGER, `statistic_manga_count` INTEGER, `statistic_manga_mean_score` REAL, `statistic_manga_standard_deviation` REAL, `statistic_manga_chapters_read` INTEGER, `statistic_manga_volumes_read` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statistic.animeCount",
+            "columnName": "statistic_anime_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "statistic.animeMeanScore",
+            "columnName": "statistic_anime_mean_score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "statistic.animeStandardDeviation",
+            "columnName": "statistic_anime_standard_deviation",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "statistic.animeMinutesWatched",
+            "columnName": "statistic_anime_minutes_watched",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "statistic.animeEpisodesWatched",
+            "columnName": "statistic_anime_episodes_watched",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "statistic.mangaCount",
+            "columnName": "statistic_manga_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "statistic.mangaMeanScore",
+            "columnName": "statistic_manga_mean_score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "statistic.mangaStandardDeviation",
+            "columnName": "statistic_manga_standard_deviation",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "statistic.mangaChaptersRead",
+            "columnName": "statistic_manga_chapters_read",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "statistic.mangaVolumesRead",
+            "columnName": "statistic_manga_volumes_read",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_statistic_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_country",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`country` TEXT NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_country_user_id_media_type_country",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "country"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_country_user_id_media_type_country` ON `${TABLE_NAME}` (`user_id`, `media_type`, `country`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`format` TEXT NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_format_user_id_media_type_format",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "format"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_format_user_id_media_type_format` ON `${TABLE_NAME}` (`user_id`, `media_type`, `format`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_genre",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`genre` TEXT NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_genre_user_id_media_type_genre",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "genre"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_genre_user_id_media_type_genre` ON `${TABLE_NAME}` (`user_id`, `media_type`, `genre`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_length",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`length` TEXT, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "length",
+            "columnName": "length",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_length_user_id_media_type_length",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "length"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_length_user_id_media_type_length` ON `${TABLE_NAME}` (`user_id`, `media_type`, `length`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_release_year",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`release_year` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "releaseYear",
+            "columnName": "release_year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_release_year_user_id_media_type_release_year",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "release_year"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_release_year_user_id_media_type_release_year` ON `${TABLE_NAME}` (`user_id`, `media_type`, `release_year`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_score",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`score` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_score_user_id_media_type_score",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "score"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_score_user_id_media_type_score` ON `${TABLE_NAME}` (`user_id`, `media_type`, `score`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_staff",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`staff_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`staff_id`) REFERENCES `staff`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "staffId",
+            "columnName": "staff_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_staff_user_id_media_type_staff_id",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "staff_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_staff_user_id_media_type_staff_id` ON `${TABLE_NAME}` (`user_id`, `media_type`, `staff_id`)"
+          },
+          {
+            "name": "index_user_statistic_staff_staff_id",
+            "unique": false,
+            "columnNames": [
+              "staff_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_statistic_staff_staff_id` ON `${TABLE_NAME}` (`staff_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "staff",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "staff_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_start_year",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`start_year` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "startYear",
+            "columnName": "start_year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_start_year_user_id_media_type_start_year",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "start_year"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_start_year_user_id_media_type_start_year` ON `${TABLE_NAME}` (`user_id`, `media_type`, `start_year`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_status",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`status` TEXT NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_status_user_id_media_type_status",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_status_user_id_media_type_status` ON `${TABLE_NAME}` (`user_id`, `media_type`, `status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_studio",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`studio_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`studio_id`) REFERENCES `studio`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "studioId",
+            "columnName": "studio_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_studio_user_id_media_type_studio_id",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "studio_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_studio_user_id_media_type_studio_id` ON `${TABLE_NAME}` (`user_id`, `media_type`, `studio_id`)"
+          },
+          {
+            "name": "index_user_statistic_studio_studio_id",
+            "unique": false,
+            "columnNames": [
+              "studio_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_statistic_studio_studio_id` ON `${TABLE_NAME}` (`studio_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "studio",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "studio_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`tag_id`) REFERENCES `tag`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_tag_user_id_media_type_tag_id",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "tag_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_tag_user_id_media_type_tag_id` ON `${TABLE_NAME}` (`user_id`, `media_type`, `tag_id`)"
+          },
+          {
+            "name": "index_user_statistic_tag_tag_id",
+            "unique": false,
+            "columnNames": [
+              "tag_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_statistic_tag_tag_id` ON `${TABLE_NAME}` (`tag_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "tag",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tag_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_statistic_voice_actor",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`staff_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `media_type` TEXT NOT NULL, `count` INTEGER NOT NULL, `mean_score` REAL NOT NULL, `media_ids` TEXT NOT NULL, `tracked_amount` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`staff_id`) REFERENCES `staff`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "staffId",
+            "columnName": "staff_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meanScore",
+            "columnName": "mean_score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "media_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackedAmount",
+            "columnName": "tracked_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_statistic_voice_actor_user_id_media_type_staff_id",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_type",
+              "staff_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_statistic_voice_actor_user_id_media_type_staff_id` ON `${TABLE_NAME}` (`user_id`, `media_type`, `staff_id`)"
+          },
+          {
+            "name": "index_user_statistic_voice_actor_staff_id",
+            "unique": false,
+            "columnNames": [
+              "staff_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_statistic_voice_actor_staff_id` ON `${TABLE_NAME}` (`staff_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "staff",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "staff_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile_favourite_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `media_id` INTEGER NOT NULL, `category` TEXT NOT NULL, `sort_index` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_profile_favourite_media_user_id_media_id_category",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "media_id",
+              "category"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_profile_favourite_media_user_id_media_id_category` ON `${TABLE_NAME}` (`user_id`, `media_id`, `category`)"
+          },
+          {
+            "name": "index_user_profile_favourite_media_user_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_favourite_media_user_id_sort_index` ON `${TABLE_NAME}` (`user_id`, `sort_index`)"
+          },
+          {
+            "name": "index_user_profile_favourite_media_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_favourite_media_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "list_status",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `sort_index` INTEGER NOT NULL, `activity_status` TEXT, `progress` TEXT, `site_url` TEXT, `activity_type` TEXT, `media_id` INTEGER, `id` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "activity_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "activity_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_list_status_user_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_status_user_id_sort_index` ON `${TABLE_NAME}` (`user_id`, `sort_index`)"
+          },
+          {
+            "name": "index_list_status_user_id_media_id",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_status_user_id_media_id` ON `${TABLE_NAME}` (`user_id`, `media_id`)"
+          },
+          {
+            "name": "index_list_status_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_list_status_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile_review",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `review_id` INTEGER NOT NULL, `sort_index` INTEGER NOT NULL, `media_id` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`review_id`) REFERENCES `review`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reviewId",
+            "columnName": "review_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_profile_review_user_id_review_id_media_id",
+            "unique": true,
+            "columnNames": [
+              "user_id",
+              "review_id",
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_profile_review_user_id_review_id_media_id` ON `${TABLE_NAME}` (`user_id`, `review_id`, `media_id`)"
+          },
+          {
+            "name": "index_user_profile_review_user_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "user_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_review_user_id_sort_index` ON `${TABLE_NAME}` (`user_id`, `sort_index`)"
+          },
+          {
+            "name": "index_user_profile_review_review_id",
+            "unique": false,
+            "columnNames": [
+              "review_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_review_review_id` ON `${TABLE_NAME}` (`review_id`)"
+          },
+          {
+            "name": "index_user_profile_review_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_review_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "review",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "review_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "media_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_type` TEXT NOT NULL, `completed_at` TEXT, `created_at` INTEGER, `hidden_from_status` INTEGER NOT NULL, `media_id` INTEGER NOT NULL, `notes` TEXT, `priority` INTEGER, `hidden` INTEGER NOT NULL, `progress` INTEGER NOT NULL, `progress_volumes` INTEGER NOT NULL, `repeat_count` INTEGER NOT NULL, `score` REAL NOT NULL, `started_at` TEXT, `list_status` TEXT NOT NULL, `updated_at` INTEGER, `user_id` INTEGER NOT NULL, `user_name` TEXT NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hiddenFromStatus",
+            "columnName": "hidden_from_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressVolumes",
+            "columnName": "progress_volumes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatCount",
+            "columnName": "repeat_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "list_status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "news",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `image` TEXT, `author` TEXT NOT NULL, `sub_title` TEXT NOT NULL, `original_link` TEXT NOT NULL, `description` TEXT, `content` TEXT NOT NULL, `published_on` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subTitle",
+            "columnName": "sub_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalLink",
+            "columnName": "original_link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedOn",
+            "columnName": "published_on",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "news_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `sub_title` TEXT NOT NULL, `description` TEXT, content=`news`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subTitle",
+            "columnName": "sub_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "news",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_news_fts_BEFORE_UPDATE BEFORE UPDATE ON `news` BEGIN DELETE FROM `news_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_news_fts_BEFORE_DELETE BEFORE DELETE ON `news` BEGIN DELETE FROM `news_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_news_fts_AFTER_UPDATE AFTER UPDATE ON `news` BEGIN INSERT INTO `news_fts`(`docid`, `title`, `sub_title`, `description`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`sub_title`, NEW.`description`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_news_fts_AFTER_INSERT AFTER INSERT ON `news` BEGIN INSERT INTO `news_fts`(`docid`, `title`, `sub_title`, `description`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`sub_title`, NEW.`description`); END"
+        ]
+      },
+      {
+        "tableName": "episode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `guid` TEXT NOT NULL, `media_id` INTEGER NOT NULL, `description` TEXT, `sub_titles` TEXT NOT NULL, `id` INTEGER NOT NULL, `series_title` TEXT NOT NULL, `series_publisher` TEXT, `series_season` TEXT, `series_keywords` TEXT NOT NULL, `series_rating` TEXT, `thumbnail_large` TEXT, `thumbnail_medium` TEXT, `available_free_time` INTEGER NOT NULL, `available_premium_time` INTEGER NOT NULL, `info_episode_duration` TEXT NOT NULL, `info_episode_title` TEXT, `info_episode_number` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "guid",
+            "columnName": "guid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitles",
+            "columnName": "sub_titles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "series.seriesTitle",
+            "columnName": "series_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "series.seriesPublisher",
+            "columnName": "series_publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "series.seriesSeason",
+            "columnName": "series_season",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "series.keywords",
+            "columnName": "series_keywords",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "series.rating",
+            "columnName": "series_rating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.large",
+            "columnName": "thumbnail_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverImage.medium",
+            "columnName": "thumbnail_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "availability.freeTime",
+            "columnName": "available_free_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "availability.premiumTime",
+            "columnName": "available_premium_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "about.episodeDuration",
+            "columnName": "info_episode_duration",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "about.episodeTitle",
+            "columnName": "info_episode_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "about.episodeNumber",
+            "columnName": "info_episode_number",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "episode_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `description` TEXT, `series_title` TEXT NOT NULL, content=`episode`)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesTitle",
+            "columnName": "series_title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "episode",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episode_fts_BEFORE_UPDATE BEFORE UPDATE ON `episode` BEGIN DELETE FROM `episode_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episode_fts_BEFORE_DELETE BEFORE DELETE ON `episode` BEGIN DELETE FROM `episode_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episode_fts_AFTER_UPDATE AFTER UPDATE ON `episode` BEGIN INSERT INTO `episode_fts`(`docid`, `title`, `description`, `series_title`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`description`, NEW.`series_title`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episode_fts_AFTER_INSERT AFTER INSERT ON `episode` BEGIN INSERT INTO `episode_fts`(`docid`, `title`, `description`, `series_title`) VALUES (NEW.`rowid`, NEW.`title`, NEW.`description`, NEW.`series_title`); END"
+        ]
+      },
+      {
+        "tableName": "character",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`age` INTEGER, `date_of_birth` TEXT, `gender` TEXT, `blood_type` TEXT, `description` TEXT, `favourites` INTEGER NOT NULL, `isFavourite` INTEGER NOT NULL, `isFavouriteBlocked` INTEGER NOT NULL, `site_url` TEXT NOT NULL, `id` INTEGER NOT NULL, `image_large` TEXT, `image_medium` TEXT, `name_alternative` TEXT, `name_alternative_spoiler` TEXT, `name_first` TEXT, `name_full` TEXT, `name_last` TEXT, `name_middle` TEXT, `name_original` TEXT, `name_user_preferred` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "age",
+            "columnName": "age",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateOfBirth",
+            "columnName": "date_of_birth",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bloodType",
+            "columnName": "blood_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "favourites",
+            "columnName": "favourites",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "isFavourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavouriteBlocked",
+            "columnName": "isFavouriteBlocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.large",
+            "columnName": "image_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "image.medium",
+            "columnName": "image_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.alternatives",
+            "columnName": "name_alternative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.alternativeSpoiler",
+            "columnName": "name_alternative_spoiler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.first",
+            "columnName": "name_first",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.full",
+            "columnName": "name_full",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.last",
+            "columnName": "name_last",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.middle",
+            "columnName": "name_middle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.original",
+            "columnName": "name_original",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.userPreferred",
+            "columnName": "name_user_preferred",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "character_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name_alternative` TEXT, `name_first` TEXT, `name_full` TEXT, `name_last` TEXT, `name_original` TEXT, content=`character`)",
+        "fields": [
+          {
+            "fieldPath": "alternatives",
+            "columnName": "name_alternative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "first",
+            "columnName": "name_first",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "full",
+            "columnName": "name_full",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "last",
+            "columnName": "name_last",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "original",
+            "columnName": "name_original",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "character",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_character_fts_BEFORE_UPDATE BEFORE UPDATE ON `character` BEGIN DELETE FROM `character_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_character_fts_BEFORE_DELETE BEFORE DELETE ON `character` BEGIN DELETE FROM `character_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_character_fts_AFTER_UPDATE AFTER UPDATE ON `character` BEGIN INSERT INTO `character_fts`(`docid`, `name_alternative`, `name_first`, `name_full`, `name_last`, `name_original`) VALUES (NEW.`rowid`, NEW.`name_alternative`, NEW.`name_first`, NEW.`name_full`, NEW.`name_last`, NEW.`name_original`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_character_fts_AFTER_INSERT AFTER INSERT ON `character` BEGIN INSERT INTO `character_fts`(`docid`, `name_alternative`, `name_first`, `name_full`, `name_last`, `name_original`) VALUES (NEW.`rowid`, NEW.`name_alternative`, NEW.`name_first`, NEW.`name_full`, NEW.`name_last`, NEW.`name_original`); END"
+        ]
+      },
+      {
+        "tableName": "studio",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`favourites` INTEGER NOT NULL, `is_animation_studio` INTEGER NOT NULL, `is_favourite` INTEGER NOT NULL, `is_favourite_blocked` INTEGER NOT NULL, `name` TEXT NOT NULL, `site_url` TEXT NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "favourites",
+            "columnName": "favourites",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAnimationStudio",
+            "columnName": "is_animation_studio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "is_favourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavouriteBlocked",
+            "columnName": "is_favourite_blocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "studio_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`studio`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "studio",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_studio_fts_BEFORE_UPDATE BEFORE UPDATE ON `studio` BEGIN DELETE FROM `studio_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_studio_fts_BEFORE_DELETE BEFORE DELETE ON `studio` BEGIN DELETE FROM `studio_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_studio_fts_AFTER_UPDATE AFTER UPDATE ON `studio` BEGIN INSERT INTO `studio_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_studio_fts_AFTER_INSERT AFTER INSERT ON `studio` BEGIN INSERT INTO `studio_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "staff",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`description` TEXT, `favourites` INTEGER NOT NULL, `is_favourite` INTEGER NOT NULL, `language` TEXT, `site_url` TEXT NOT NULL, `updated_at` INTEGER, `id` INTEGER NOT NULL, `attribute_age` INTEGER, `attribute_date_of_birth` TEXT, `attribute_date_of_death` TEXT, `attribute_gender` TEXT, `attribute_blood_type` TEXT, `attribute_home_town` TEXT, `attribute_primary_occupations` TEXT, `attribute_year_active_start` INTEGER, `attribute_year_active_end` INTEGER, `image_large` TEXT, `image_medium` TEXT, `name_alternative` TEXT, `name_first` TEXT, `name_full` TEXT, `name_last` TEXT, `name_original` TEXT, `name_user_preferred` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "favourites",
+            "columnName": "favourites",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavourite",
+            "columnName": "is_favourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attribute.age",
+            "columnName": "attribute_age",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attribute.dateOfBirth",
+            "columnName": "attribute_date_of_birth",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attribute.dateOfDeath",
+            "columnName": "attribute_date_of_death",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attribute.gender",
+            "columnName": "attribute_gender",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attribute.bloodType",
+            "columnName": "attribute_blood_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attribute.homeTown",
+            "columnName": "attribute_home_town",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attribute.primaryOccupations",
+            "columnName": "attribute_primary_occupations",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attribute.yearActiveStart",
+            "columnName": "attribute_year_active_start",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attribute.yearActiveEnd",
+            "columnName": "attribute_year_active_end",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "image.large",
+            "columnName": "image_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "image.medium",
+            "columnName": "image_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.alternatives",
+            "columnName": "name_alternative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.first",
+            "columnName": "name_first",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.full",
+            "columnName": "name_full",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.last",
+            "columnName": "name_last",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.original",
+            "columnName": "name_original",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name.userPreferred",
+            "columnName": "name_user_preferred",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "staff_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name_alternative` TEXT, `name_first` TEXT, `name_full` TEXT, `name_last` TEXT, `name_original` TEXT, content=`staff`)",
+        "fields": [
+          {
+            "fieldPath": "alternatives",
+            "columnName": "name_alternative",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "first",
+            "columnName": "name_first",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "full",
+            "columnName": "name_full",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "last",
+            "columnName": "name_last",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "original",
+            "columnName": "name_original",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "staff",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_staff_fts_BEFORE_UPDATE BEFORE UPDATE ON `staff` BEGIN DELETE FROM `staff_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_staff_fts_BEFORE_DELETE BEFORE DELETE ON `staff` BEGIN DELETE FROM `staff_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_staff_fts_AFTER_UPDATE AFTER UPDATE ON `staff` BEGIN INSERT INTO `staff_fts`(`docid`, `name_alternative`, `name_first`, `name_full`, `name_last`, `name_original`) VALUES (NEW.`rowid`, NEW.`name_alternative`, NEW.`name_first`, NEW.`name_full`, NEW.`name_last`, NEW.`name_original`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_staff_fts_AFTER_INSERT AFTER INSERT ON `staff` BEGIN INSERT INTO `staff_fts`(`docid`, `name_alternative`, `name_first`, `name_full`, `name_last`, `name_original`) VALUES (NEW.`rowid`, NEW.`name_alternative`, NEW.`name_first`, NEW.`name_full`, NEW.`name_last`, NEW.`name_original`); END"
+        ]
+      },
+      {
+        "tableName": "link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `color` TEXT, `icon` TEXT, `is_disabled` INTEGER, `language` TEXT, `notes` TEXT, `site_id` INTEGER, `link_type` TEXT, `site` TEXT NOT NULL, `url` TEXT NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDisabled",
+            "columnName": "is_disabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "siteId",
+            "columnName": "site_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "linkType",
+            "columnName": "link_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "site",
+            "columnName": "site",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_link_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_link_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "rank",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `all_time` INTEGER, `context` TEXT NOT NULL, `format` TEXT NOT NULL, `rank` INTEGER NOT NULL, `season` TEXT, `type` TEXT NOT NULL, `year` INTEGER, `id` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allTime",
+            "columnName": "all_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "context",
+            "columnName": "context",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rank_media_id_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_rank_media_id_id` ON `${TABLE_NAME}` (`media_id`, `id`)"
+          },
+          {
+            "name": "index_rank_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rank_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "media_character_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `character_id` INTEGER NOT NULL, `role` TEXT, `media_role_name` TEXT, `sort_index` INTEGER NOT NULL, `image_large` TEXT, `image_medium` TEXT, `name_first` TEXT, `name_full` TEXT, `name_last` TEXT, `name_middle` TEXT, `name_native` TEXT, `name_user_preferred` TEXT, `name_alternative` TEXT NOT NULL, `name_alternative_spoiler` TEXT NOT NULL, `site_url` TEXT, `voice_actor_id` INTEGER, `voice_actor_name_full` TEXT, `voice_actor_name_user_preferred` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "characterId",
+            "columnName": "character_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaRoleName",
+            "columnName": "media_role_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageLarge",
+            "columnName": "image_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageMedium",
+            "columnName": "image_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameFirst",
+            "columnName": "name_first",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameFull",
+            "columnName": "name_full",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameLast",
+            "columnName": "name_last",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameMiddle",
+            "columnName": "name_middle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameNative",
+            "columnName": "name_native",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameUserPreferred",
+            "columnName": "name_user_preferred",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameAlternative",
+            "columnName": "name_alternative",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameAlternativeSpoiler",
+            "columnName": "name_alternative_spoiler",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "voiceActorId",
+            "columnName": "voice_actor_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "voiceActorNameFull",
+            "columnName": "voice_actor_name_full",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "voiceActorNameUserPreferred",
+            "columnName": "voice_actor_name_user_preferred",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_character_connection_media_id_character_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "character_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_character_connection_media_id_character_id` ON `${TABLE_NAME}` (`media_id`, `character_id`)"
+          },
+          {
+            "name": "index_media_character_connection_media_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "media_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_character_connection_media_id_sort_index` ON `${TABLE_NAME}` (`media_id`, `sort_index`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_staff_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `staff_id` INTEGER NOT NULL, `role` TEXT, `language` TEXT, `sort_index` INTEGER NOT NULL, `image_large` TEXT, `image_medium` TEXT, `name_first` TEXT, `name_full` TEXT, `name_last` TEXT, `name_middle` TEXT, `name_native` TEXT, `name_user_preferred` TEXT, `name_alternative` TEXT NOT NULL, `name_alternative_spoiler` TEXT NOT NULL, `site_url` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staffId",
+            "columnName": "staff_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageLarge",
+            "columnName": "image_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageMedium",
+            "columnName": "image_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameFirst",
+            "columnName": "name_first",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameFull",
+            "columnName": "name_full",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameLast",
+            "columnName": "name_last",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameMiddle",
+            "columnName": "name_middle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameNative",
+            "columnName": "name_native",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameUserPreferred",
+            "columnName": "name_user_preferred",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nameAlternative",
+            "columnName": "name_alternative",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameAlternativeSpoiler",
+            "columnName": "name_alternative_spoiler",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_staff_connection_media_id_staff_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "staff_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_staff_connection_media_id_staff_id` ON `${TABLE_NAME}` (`media_id`, `staff_id`)"
+          },
+          {
+            "name": "index_media_staff_connection_media_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "media_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_staff_connection_media_id_sort_index` ON `${TABLE_NAME}` (`media_id`, `sort_index`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_studio_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `entry_id` INTEGER NOT NULL, `studio_id` INTEGER NOT NULL, `studio_name` TEXT NOT NULL, `studio_favourites` INTEGER, `studio_is_animation` INTEGER, `studio_site_url` TEXT, `media_title` TEXT, `media_cover_image_large` TEXT, `media_cover_image_medium` TEXT, `media_format` TEXT, `media_start_year` INTEGER, `media_average_score` INTEGER, `is_main` INTEGER NOT NULL, `sort_index` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryId",
+            "columnName": "entry_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studioId",
+            "columnName": "studio_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studioName",
+            "columnName": "studio_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studioFavourites",
+            "columnName": "studio_favourites",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "studioIsAnimationStudio",
+            "columnName": "studio_is_animation",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "studioSiteUrl",
+            "columnName": "studio_site_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaTitle",
+            "columnName": "media_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaCoverImageLarge",
+            "columnName": "media_cover_image_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaCoverImageMedium",
+            "columnName": "media_cover_image_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaFormat",
+            "columnName": "media_format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaStartYear",
+            "columnName": "media_start_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mediaAverageScore",
+            "columnName": "media_average_score",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isMain",
+            "columnName": "is_main",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_studio_connection_media_id_entry_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "entry_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_studio_connection_media_id_entry_id` ON `${TABLE_NAME}` (`media_id`, `entry_id`)"
+          },
+          {
+            "name": "index_media_studio_connection_media_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "media_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_studio_connection_media_id_sort_index` ON `${TABLE_NAME}` (`media_id`, `sort_index`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_relation_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `entry_id` INTEGER NOT NULL, `relation` TEXT, `sort_index` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `target_id` INTEGER NOT NULL, `target_type` TEXT NOT NULL, `target_format` TEXT, `target_status` TEXT, `target_start_date` TEXT NOT NULL, `target_episodes` INTEGER NOT NULL, `target_chapters` INTEGER NOT NULL, `target_volumes` INTEGER NOT NULL, `target_is_favourite` INTEGER NOT NULL, `target_mean_score` INTEGER NOT NULL, `target_average_score` INTEGER NOT NULL, `target_personal_score` REAL, `target_next_airing_at` INTEGER, `target_next_airing_episode` INTEGER, `target_next_airing_id` INTEGER, `target_image_color` TEXT, `target_image_large` TEXT, `target_image_medium` TEXT, `target_title_english` TEXT, `target_title_native` TEXT, `target_title_romaji` TEXT, `target_title_user_preferred` TEXT, `target_media_list_status` TEXT, `target_media_list_notes` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryId",
+            "columnName": "entry_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relation",
+            "columnName": "relation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.id",
+            "columnName": "target_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.type",
+            "columnName": "target_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.format",
+            "columnName": "target_format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.status",
+            "columnName": "target_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.startDate",
+            "columnName": "target_start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.episodes",
+            "columnName": "target_episodes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.chapters",
+            "columnName": "target_chapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.volumes",
+            "columnName": "target_volumes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.isFavourite",
+            "columnName": "target_is_favourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.meanScore",
+            "columnName": "target_mean_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.averageScore",
+            "columnName": "target_average_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.personalScore",
+            "columnName": "target_personal_score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "target.nextAiringAt",
+            "columnName": "target_next_airing_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.nextAiringEpisode",
+            "columnName": "target_next_airing_episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.nextAiringId",
+            "columnName": "target_next_airing_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.image.color",
+            "columnName": "target_image_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.image.large",
+            "columnName": "target_image_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.image.medium",
+            "columnName": "target_image_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.english",
+            "columnName": "target_title_english",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.nativeTitle",
+            "columnName": "target_title_native",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.romaji",
+            "columnName": "target_title_romaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.userPreferred",
+            "columnName": "target_title_user_preferred",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.mediaList.status",
+            "columnName": "target_media_list_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.mediaList.notes",
+            "columnName": "target_media_list_notes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_relation_connection_media_id_entry_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "entry_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_relation_connection_media_id_entry_id` ON `${TABLE_NAME}` (`media_id`, `entry_id`)"
+          },
+          {
+            "name": "index_media_relation_connection_media_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "media_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_relation_connection_media_id_sort_index` ON `${TABLE_NAME}` (`media_id`, `sort_index`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_recommendation_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, `entry_id` INTEGER NOT NULL, `rating` INTEGER, `user_name` TEXT, `user_rating` TEXT, `sort_index` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `target_id` INTEGER NOT NULL, `target_type` TEXT NOT NULL, `target_format` TEXT, `target_status` TEXT, `target_start_date` TEXT NOT NULL, `target_episodes` INTEGER NOT NULL, `target_chapters` INTEGER NOT NULL, `target_volumes` INTEGER NOT NULL, `target_is_favourite` INTEGER NOT NULL, `target_mean_score` INTEGER NOT NULL, `target_average_score` INTEGER NOT NULL, `target_personal_score` REAL, `target_next_airing_at` INTEGER, `target_next_airing_episode` INTEGER, `target_next_airing_id` INTEGER, `target_image_color` TEXT, `target_image_large` TEXT, `target_image_medium` TEXT, `target_title_english` TEXT, `target_title_native` TEXT, `target_title_romaji` TEXT, `target_title_user_preferred` TEXT, `target_media_list_status` TEXT, `target_media_list_notes` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryId",
+            "columnName": "entry_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userRating",
+            "columnName": "user_rating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.id",
+            "columnName": "target_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.type",
+            "columnName": "target_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.format",
+            "columnName": "target_format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.status",
+            "columnName": "target_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.startDate",
+            "columnName": "target_start_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.episodes",
+            "columnName": "target_episodes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.chapters",
+            "columnName": "target_chapters",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.volumes",
+            "columnName": "target_volumes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.isFavourite",
+            "columnName": "target_is_favourite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.meanScore",
+            "columnName": "target_mean_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.averageScore",
+            "columnName": "target_average_score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "target.personalScore",
+            "columnName": "target_personal_score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "target.nextAiringAt",
+            "columnName": "target_next_airing_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.nextAiringEpisode",
+            "columnName": "target_next_airing_episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.nextAiringId",
+            "columnName": "target_next_airing_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "target.image.color",
+            "columnName": "target_image_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.image.large",
+            "columnName": "target_image_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.image.medium",
+            "columnName": "target_image_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.english",
+            "columnName": "target_title_english",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.nativeTitle",
+            "columnName": "target_title_native",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.romaji",
+            "columnName": "target_title_romaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.title.userPreferred",
+            "columnName": "target_title_user_preferred",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.mediaList.status",
+            "columnName": "target_media_list_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "target.mediaList.notes",
+            "columnName": "target_media_list_notes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_recommendation_connection_media_id_entry_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "entry_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_recommendation_connection_media_id_entry_id` ON `${TABLE_NAME}` (`media_id`, `entry_id`)"
+          },
+          {
+            "name": "index_media_recommendation_connection_media_id_sort_index",
+            "unique": false,
+            "columnNames": [
+              "media_id",
+              "sort_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_recommendation_connection_media_id_sort_index` ON `${TABLE_NAME}` (`media_id`, `sort_index`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` INTEGER NOT NULL, PRIMARY KEY(`media_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "media_id"
+          ]
+        }
+      },
+      {
+        "tableName": "media_score_distribution",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`amount` INTEGER NOT NULL, `score` INTEGER NOT NULL, `media_id` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_score_distribution_media_id_score",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "score"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_score_distribution_media_id_score` ON `${TABLE_NAME}` (`media_id`, `score`)"
+          },
+          {
+            "name": "index_media_score_distribution_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_score_distribution_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "media_status_distribution",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`amount` INTEGER NOT NULL, `status` TEXT, `media_id` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT, FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_status_distribution_media_id_status",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_status_distribution_media_id_status` ON `${TABLE_NAME}` (`media_id`, `status`)"
+          },
+          {
+            "name": "index_media_status_distribution_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_status_distribution_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`enabled` INTEGER NOT NULL, `list_name` TEXT NOT NULL, `media_list_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `user_name` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`media_list_id`) REFERENCES `media_list`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listName",
+            "columnName": "list_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaListId",
+            "columnName": "media_list_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_custom_list_media_list_id_list_name_user_id_user_name",
+            "unique": true,
+            "columnNames": [
+              "media_list_id",
+              "list_name",
+              "user_id",
+              "user_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_custom_list_media_list_id_list_name_user_id_user_name` ON `${TABLE_NAME}` (`media_list_id`, `list_name`, `user_id`, `user_name`)"
+          },
+          {
+            "name": "index_custom_list_media_list_id",
+            "unique": false,
+            "columnNames": [
+              "media_list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_list_media_list_id` ON `${TABLE_NAME}` (`media_list_id`)"
+          },
+          {
+            "name": "index_custom_list_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_list_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media_list",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_list_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_score",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`score` REAL NOT NULL, `score_name` TEXT NOT NULL, `media_list_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `user_name` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`media_list_id`) REFERENCES `media_list`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scoreName",
+            "columnName": "score_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaListId",
+            "columnName": "media_list_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_custom_score_media_list_id_score_name_user_id_user_name",
+            "unique": true,
+            "columnNames": [
+              "media_list_id",
+              "score_name",
+              "user_id",
+              "user_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_custom_score_media_list_id_score_name_user_id_user_name` ON `${TABLE_NAME}` (`media_list_id`, `score_name`, `user_id`, `user_name`)"
+          },
+          {
+            "name": "index_custom_score_media_list_id",
+            "unique": false,
+            "columnNames": [
+              "media_list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_score_media_list_id` ON `${TABLE_NAME}` (`media_list_id`)"
+          },
+          {
+            "name": "index_custom_score_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_score_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media_list",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_list_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_previous_name",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `name` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_previous_name_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_previous_name_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "review",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`body` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `media_id` INTEGER NOT NULL, `is_private` INTEGER NOT NULL, `rating` INTEGER NOT NULL, `rating_amount` INTEGER NOT NULL, `score` INTEGER NOT NULL, `site_url` TEXT NOT NULL, `summary` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `user_rating` TEXT NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`media_id`) REFERENCES `media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "is_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingAmount",
+            "columnName": "rating_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteUrl",
+            "columnName": "site_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userRating",
+            "columnName": "user_rating",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_review_media_id_user_id",
+            "unique": false,
+            "columnNames": [
+              "media_id",
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_review_media_id_user_id` ON `${TABLE_NAME}` (`media_id`, `user_id`)"
+          },
+          {
+            "name": "index_review_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_review_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          },
+          {
+            "name": "index_review_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_review_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` INTEGER NOT NULL, `unread_notifications` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`user_id`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unreadNotifications",
+            "columnName": "unread_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_notification_user_id",
+            "unique": true,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_notification_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `settings_analytics_enabled` INTEGER NOT NULL, `settings_platform_source` TEXT, `image_banner` TEXT NOT NULL, `image_poster` TEXT NOT NULL, `image_loading` TEXT NOT NULL, `image_error` TEXT NOT NULL, `image_info` TEXT NOT NULL, `image_standard` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.analyticsEnabled",
+            "columnName": "settings_analytics_enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.platformSource",
+            "columnName": "settings_platform_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "image.banner",
+            "columnName": "image_banner",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.poster",
+            "columnName": "image_poster",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.loading",
+            "columnName": "image_loading",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.error",
+            "columnName": "image_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.info",
+            "columnName": "image_info",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image.standard",
+            "columnName": "image_standard",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "edge_media_episode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` TEXT NOT NULL, `season_number` INTEGER NOT NULL, `episode_number` INTEGER NOT NULL, `name` TEXT, `overview` TEXT, `image` TEXT, `poster` TEXT, `runtime` INTEGER, `absolute_episode_number` INTEGER, `air_date` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`media_id`, `season_number`) REFERENCES `edge_media_season`(`media_id`, `season_number`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "season_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episode_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "poster",
+            "columnName": "poster",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "runtime",
+            "columnName": "runtime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "absoluteEpisodeNumber",
+            "columnName": "absolute_episode_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "airDate",
+            "columnName": "air_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_media_episode_media_id_season_number_episode_number",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "season_number",
+              "episode_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_media_episode_media_id_season_number_episode_number` ON `${TABLE_NAME}` (`media_id`, `season_number`, `episode_number`)"
+          },
+          {
+            "name": "index_edge_media_episode_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_media_episode_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          },
+          {
+            "name": "index_edge_media_episode_season_number",
+            "unique": false,
+            "columnNames": [
+              "season_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_media_episode_season_number` ON `${TABLE_NAME}` (`season_number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_media_season",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id",
+              "season_number"
+            ],
+            "referencedColumns": [
+              "media_id",
+              "season_number"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_config_genre",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`config_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`config_id`) REFERENCES `edge_config`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "configId",
+            "columnName": "config_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_config_genre_config_id_id",
+            "unique": true,
+            "columnNames": [
+              "config_id",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_config_genre_config_id_id` ON `${TABLE_NAME}` (`config_id`, `id`)"
+          },
+          {
+            "name": "index_edge_config_genre_config_id",
+            "unique": false,
+            "columnNames": [
+              "config_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_config_genre_config_id` ON `${TABLE_NAME}` (`config_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_config",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "config_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_media_image",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` TEXT NOT NULL, `type` TEXT NOT NULL, `url` TEXT NOT NULL, `height` INTEGER NOT NULL, `width` INTEGER NOT NULL, `locale` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`media_id`) REFERENCES `edge_media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_media_image_media_id_url_type",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "url",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_media_image_media_id_url_type` ON `${TABLE_NAME}` (`media_id`, `url`, `type`)"
+          },
+          {
+            "name": "index_edge_media_image_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_media_image_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`banner` TEXT, `description` TEXT, `fanart` TEXT, `format` TEXT, `homepage` TEXT, `aired_episodes` INTEGER, `broadcast` TEXT, `source` TEXT, `status` TEXT, `age_rating` TEXT, `is_adult` INTEGER, `kind` TEXT NOT NULL, `chapters` INTEGER, `volumes` INTEGER, `more_info` TEXT, `published_from` INTEGER, `published_to` INTEGER, `updated_at` INTEGER NOT NULL, `id` TEXT NOT NULL, `title_canonical` TEXT, `title_english` TEXT, `title_harigana` TEXT, `title_japanese` TEXT, `title_romaji` TEXT, `title_synonyms` TEXT, `cover_medium` TEXT, `cover_large` TEXT, `cover_xlarge` TEXT, `cover_color` TEXT, `id_ani_db` INTEGER, `id_ani_list` INTEGER, `id_anime_planet` TEXT, `id_ani_search` INTEGER, `id_imdb` TEXT, `id_kitsu` INTEGER, `id_live_chart` INTEGER, `id_my_anime_list` INTEGER, `id_notify` TEXT, `id_shoboi` INTEGER, `id_slug` TEXT, `id_themoviedb` INTEGER, `id_trakt` INTEGER, `id_tv_db` INTEGER, `id_tv_maze` INTEGER, `id_tv_rage` TEXT, `schedule_first_air_date` INTEGER, `schedule_last_air_date` INTEGER, `schedule_next_episode_id` INTEGER, `schedule_last_episode_id` INTEGER, `schedule_next_episode_detail_id` INTEGER, `schedule_next_episode_detail_air_date` INTEGER, `schedule_next_episode_detail_episode_number` INTEGER, `schedule_next_episode_detail_image` TEXT, `schedule_next_episode_detail_name` TEXT, `schedule_next_episode_detail_overview` TEXT, `schedule_next_episode_detail_production_code` TEXT, `schedule_next_episode_detail_runtime` INTEGER, `schedule_next_episode_detail_season_number` INTEGER, `schedule_next_episode_detail_tmdb_id` INTEGER, `schedule_last_episode_detail_id` INTEGER, `schedule_last_episode_detail_air_date` INTEGER, `schedule_last_episode_detail_episode_number` INTEGER, `schedule_last_episode_detail_image` TEXT, `schedule_last_episode_detail_name` TEXT, `schedule_last_episode_detail_overview` TEXT, `schedule_last_episode_detail_production_code` TEXT, `schedule_last_episode_detail_runtime` INTEGER, `schedule_last_episode_detail_season_number` INTEGER, `schedule_last_episode_detail_tmdb_id` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "banner",
+            "columnName": "banner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fanart",
+            "columnName": "fanart",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "homepage",
+            "columnName": "homepage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "airedEpisodes",
+            "columnName": "aired_episodes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "broadcast",
+            "columnName": "broadcast",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ageRating",
+            "columnName": "age_rating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAdult",
+            "columnName": "is_adult",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumes",
+            "columnName": "volumes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "moreInfo",
+            "columnName": "more_info",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedFrom",
+            "columnName": "published_from",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "publishedTo",
+            "columnName": "published_to",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title.canonical",
+            "columnName": "title_canonical",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.english",
+            "columnName": "title_english",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.harigana",
+            "columnName": "title_harigana",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.japanese",
+            "columnName": "title_japanese",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.romaji",
+            "columnName": "title_romaji",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title.synonyms",
+            "columnName": "title_synonyms",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cover.medium",
+            "columnName": "cover_medium",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cover.large",
+            "columnName": "cover_large",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cover.extraLarge",
+            "columnName": "cover_xlarge",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cover.color",
+            "columnName": "cover_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "externalIds.aniDb",
+            "columnName": "id_ani_db",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.aniList",
+            "columnName": "id_ani_list",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.animePlanet",
+            "columnName": "id_anime_planet",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "externalIds.aniSearch",
+            "columnName": "id_ani_search",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.imdb",
+            "columnName": "id_imdb",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "externalIds.kitsu",
+            "columnName": "id_kitsu",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.liveChart",
+            "columnName": "id_live_chart",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.myAnimeList",
+            "columnName": "id_my_anime_list",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.notify",
+            "columnName": "id_notify",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "externalIds.shoboi",
+            "columnName": "id_shoboi",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.slug",
+            "columnName": "id_slug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "externalIds.tmdb",
+            "columnName": "id_themoviedb",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.trakt",
+            "columnName": "id_trakt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.tvDb",
+            "columnName": "id_tv_db",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.tvMaze",
+            "columnName": "id_tv_maze",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalIds.tvRage",
+            "columnName": "id_tv_rage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.firstAirDate",
+            "columnName": "schedule_first_air_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastAirDate",
+            "columnName": "schedule_last_air_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.nextEpisodeId",
+            "columnName": "schedule_next_episode_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastEpisodeId",
+            "columnName": "schedule_last_episode_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.id",
+            "columnName": "schedule_next_episode_detail_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.airDate",
+            "columnName": "schedule_next_episode_detail_air_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.episodeNumber",
+            "columnName": "schedule_next_episode_detail_episode_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.image",
+            "columnName": "schedule_next_episode_detail_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.name",
+            "columnName": "schedule_next_episode_detail_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.overview",
+            "columnName": "schedule_next_episode_detail_overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.productionCode",
+            "columnName": "schedule_next_episode_detail_production_code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.runtime",
+            "columnName": "schedule_next_episode_detail_runtime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.seasonNumber",
+            "columnName": "schedule_next_episode_detail_season_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.nextEpisode.tmdbId",
+            "columnName": "schedule_next_episode_detail_tmdb_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.id",
+            "columnName": "schedule_last_episode_detail_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.airDate",
+            "columnName": "schedule_last_episode_detail_air_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.episodeNumber",
+            "columnName": "schedule_last_episode_detail_episode_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.image",
+            "columnName": "schedule_last_episode_detail_image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.name",
+            "columnName": "schedule_last_episode_detail_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.overview",
+            "columnName": "schedule_last_episode_detail_overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.productionCode",
+            "columnName": "schedule_last_episode_detail_production_code",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.runtime",
+            "columnName": "schedule_last_episode_detail_runtime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.seasonNumber",
+            "columnName": "schedule_last_episode_detail_season_number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "schedule.lastEpisode.tmdbId",
+            "columnName": "schedule_last_episode_detail_tmdb_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_media_id_my_anime_list",
+            "unique": true,
+            "columnNames": [
+              "id_my_anime_list"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_media_id_my_anime_list` ON `${TABLE_NAME}` (`id_my_anime_list`)"
+          },
+          {
+            "name": "index_edge_media_id_ani_list",
+            "unique": true,
+            "columnNames": [
+              "id_ani_list"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_media_id_ani_list` ON `${TABLE_NAME}` (`id_ani_list`)"
+          }
+        ]
+      },
+      {
+        "tableName": "edge_config_navigation",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`config_id` INTEGER NOT NULL, `criteria` TEXT NOT NULL, `destination` TEXT NOT NULL, `i18n` TEXT NOT NULL, `icon` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `group_authenticated` INTEGER NOT NULL, `group_i18n` TEXT NOT NULL, FOREIGN KEY(`config_id`) REFERENCES `edge_config`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "configId",
+            "columnName": "config_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "criteria",
+            "columnName": "criteria",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "i18n",
+            "columnName": "i18n",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "group.authenticated",
+            "columnName": "group_authenticated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "group.i18n",
+            "columnName": "group_i18n",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_config_navigation_config_id_id",
+            "unique": true,
+            "columnNames": [
+              "config_id",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_config_navigation_config_id_id` ON `${TABLE_NAME}` (`config_id`, `id`)"
+          },
+          {
+            "name": "index_edge_config_navigation_config_id",
+            "unique": false,
+            "columnNames": [
+              "config_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_config_navigation_config_id` ON `${TABLE_NAME}` (`config_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_config",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "config_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_media_network",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` TEXT NOT NULL, `network_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `category` TEXT NOT NULL, `is_primary` INTEGER NOT NULL, `logo_path` TEXT, `origin_country` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`media_id`) REFERENCES `edge_media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "network_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrimary",
+            "columnName": "is_primary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logo_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originCountry",
+            "columnName": "origin_country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_media_network_media_id_network_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "network_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_media_network_media_id_network_id` ON `${TABLE_NAME}` (`media_id`, `network_id`)"
+          },
+          {
+            "name": "index_edge_media_network_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_media_network_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_news",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cursor` TEXT NOT NULL, `news_id` TEXT NOT NULL, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `image` TEXT, `source` TEXT, `published_at` INTEGER, `description` TEXT, `content` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "cursor",
+            "columnName": "cursor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newsId",
+            "columnName": "news_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "published_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_news_cursor",
+            "unique": true,
+            "columnNames": [
+              "cursor"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_news_cursor` ON `${TABLE_NAME}` (`cursor`)"
+          }
+        ]
+      },
+      {
+        "tableName": "edge_media_season",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` TEXT NOT NULL, `season_number` INTEGER NOT NULL, `name` TEXT, `tmdb_id` INTEGER, `overview` TEXT, `episode_count` INTEGER, `cover` TEXT, `air_date` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`media_id`) REFERENCES `edge_media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "season_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdb_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeCount",
+            "columnName": "episode_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "airDate",
+            "columnName": "air_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_media_season_media_id_season_number",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "season_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_media_season_media_id_season_number` ON `${TABLE_NAME}` (`media_id`, `season_number`)"
+          },
+          {
+            "name": "index_edge_media_season_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_media_season_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_anime_theme",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` TEXT NOT NULL, `theme_id` TEXT NOT NULL, `slug` TEXT, `type` TEXT NOT NULL, `sequence` INTEGER NOT NULL, `song_id` INTEGER, `song_title` TEXT NOT NULL, `id` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`media_id`) REFERENCES `edge_media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "themeId",
+            "columnName": "theme_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songTitle",
+            "columnName": "song_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_anime_theme_media_id_theme_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "theme_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_anime_theme_media_id_theme_id` ON `${TABLE_NAME}` (`media_id`, `theme_id`)"
+          },
+          {
+            "name": "index_edge_anime_theme_theme_id",
+            "unique": true,
+            "columnNames": [
+              "theme_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_anime_theme_theme_id` ON `${TABLE_NAME}` (`theme_id`)"
+          },
+          {
+            "name": "index_edge_anime_theme_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_anime_theme_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_anime_theme_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`theme_id` TEXT NOT NULL, `entry_id` TEXT NOT NULL, `episodes` TEXT, `notes` TEXT, `nsfw` INTEGER NOT NULL, `spoiler` INTEGER NOT NULL, `version` INTEGER NOT NULL, `id` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`theme_id`) REFERENCES `edge_anime_theme`(`theme_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "themeId",
+            "columnName": "theme_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryId",
+            "columnName": "entry_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodes",
+            "columnName": "episodes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nsfw",
+            "columnName": "nsfw",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoiler",
+            "columnName": "spoiler",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_anime_theme_entry_theme_id_entry_id",
+            "unique": true,
+            "columnNames": [
+              "theme_id",
+              "entry_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_anime_theme_entry_theme_id_entry_id` ON `${TABLE_NAME}` (`theme_id`, `entry_id`)"
+          },
+          {
+            "name": "index_edge_anime_theme_entry_entry_id",
+            "unique": true,
+            "columnNames": [
+              "entry_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_anime_theme_entry_entry_id` ON `${TABLE_NAME}` (`entry_id`)"
+          },
+          {
+            "name": "index_edge_anime_theme_entry_theme_id",
+            "unique": false,
+            "columnNames": [
+              "theme_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_anime_theme_entry_theme_id` ON `${TABLE_NAME}` (`theme_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_anime_theme",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "theme_id"
+            ],
+            "referencedColumns": [
+              "theme_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_anime_theme_video",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entry_id` TEXT NOT NULL, `video_id` TEXT NOT NULL, `link` TEXT NOT NULL, `resolution` INTEGER, `source` TEXT, `subbed` INTEGER NOT NULL, `lyrics` INTEGER NOT NULL, `nc` INTEGER NOT NULL, `uncen` INTEGER NOT NULL, `tags` TEXT, `overlap` TEXT, `audio_id` INTEGER, `audio_link` TEXT, `id` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`entry_id`) REFERENCES `edge_anime_theme_entry`(`entry_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "entryId",
+            "columnName": "entry_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "video_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resolution",
+            "columnName": "resolution",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subbed",
+            "columnName": "subbed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nc",
+            "columnName": "nc",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uncen",
+            "columnName": "uncen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "overlap",
+            "columnName": "overlap",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "audioLink",
+            "columnName": "audio_link",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_anime_theme_video_entry_id_video_id",
+            "unique": true,
+            "columnNames": [
+              "entry_id",
+              "video_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_anime_theme_video_entry_id_video_id` ON `${TABLE_NAME}` (`entry_id`, `video_id`)"
+          },
+          {
+            "name": "index_edge_anime_theme_video_entry_id",
+            "unique": false,
+            "columnNames": [
+              "entry_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_anime_theme_video_entry_id` ON `${TABLE_NAME}` (`entry_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_anime_theme_entry",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "entry_id"
+            ],
+            "referencedColumns": [
+              "entry_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "edge_media_trailer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` TEXT NOT NULL, `trailer_id` TEXT NOT NULL, `site` TEXT NOT NULL, `thumbnail` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`media_id`) REFERENCES `edge_media`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trailerId",
+            "columnName": "trailer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "site",
+            "columnName": "site",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_edge_media_trailer_media_id_trailer_id",
+            "unique": true,
+            "columnNames": [
+              "media_id",
+              "trailer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_edge_media_trailer_media_id_trailer_id` ON `${TABLE_NAME}` (`media_id`, `trailer_id`)"
+          },
+          {
+            "name": "index_edge_media_trailer_media_id",
+            "unique": false,
+            "columnNames": [
+              "media_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_edge_media_trailer_media_id` ON `${TABLE_NAME}` (`media_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "edge_media",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "media_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "media_list_count",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select count(media_list.id) as list_count, media_list.media_type, media_list.list_status, media_list.user_id\n            from media_list\n            group by media_list.user_id, media_list.media_type, media_list.list_status"
+      },
+      {
+        "viewName": "custom_list_count",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select count(custom_list.id) as list_count, media_list.media_type, custom_list.user_id, custom_list.list_name\n            from custom_list\n            inner join media_list on media_list.id = custom_list.media_list_id\n            where custom_list.enabled = 1\n            group by custom_list.user_id, media_list.media_type, custom_list.list_name"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'edcee7bec3449c0c770cde56e6523126')"
+    ]
+  }
+}

--- a/data/src/androidTest/kotlin/co/anitrend/data/android/database/migration/AniTrendStoreMigrationTest.kt
+++ b/data/src/androidTest/kotlin/co/anitrend/data/android/database/migration/AniTrendStoreMigrationTest.kt
@@ -96,6 +96,31 @@ class AniTrendStoreMigrationTest {
         assertTrue(columns.contains("media_average_score"))
     }
 
+    @Test
+    fun migrate23To24AddsForeignKeyIndices() {
+        helper.createDatabase(TEST_DB, 23).apply {
+            close()
+        }
+
+        val migrated = helper.runMigrationsAndValidate(TEST_DB, 24, true, *MIGRATIONS)
+        val indices = mutableSetOf<String>()
+
+        migrated.query("SELECT name FROM sqlite_master WHERE type = 'index'").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            while (cursor.moveToNext()) {
+                indices += cursor.getString(nameIndex)
+            }
+        }
+
+        assertTrue(indices.contains("index_user_statistic_staff_staff_id"))
+        assertTrue(indices.contains("index_user_statistic_studio_studio_id"))
+        assertTrue(indices.contains("index_user_statistic_tag_tag_id"))
+        assertTrue(indices.contains("index_user_statistic_voice_actor_staff_id"))
+        assertTrue(indices.contains("index_user_profile_favourite_media_media_id"))
+        assertTrue(indices.contains("index_user_profile_review_review_id"))
+        assertTrue(indices.contains("index_user_profile_review_media_id"))
+    }
+
     private companion object {
         const val TEST_DB = "migration-test"
     }

--- a/data/src/main/kotlin/co/anitrend/data/android/database/AniTrendStore.kt
+++ b/data/src/main/kotlin/co/anitrend/data/android/database/AniTrendStore.kt
@@ -155,7 +155,7 @@ internal abstract class AniTrendStore :
     RoomDatabase(),
     IAniTrendStore {
     companion object {
-        const val DATABASE_SCHEMA_VERSION = 23
+        const val DATABASE_SCHEMA_VERSION = 24
 
         internal fun create(applicationContext: Context): IAniTrendStore =
             Room

--- a/data/src/main/kotlin/co/anitrend/data/android/database/migration/MigrationHelper.kt
+++ b/data/src/main/kotlin/co/anitrend/data/android/database/migration/MigrationHelper.kt
@@ -301,4 +301,15 @@ internal val MIGRATIONS =
                 "ALTER TABLE `media_studio_connection` ADD COLUMN `media_average_score` INTEGER",
             )
         },
+        migrationOfStatements(23, 24) {
+            arrayOf(
+                "CREATE INDEX IF NOT EXISTS `index_user_statistic_staff_staff_id` ON `user_statistic_staff` (`staff_id`)",
+                "CREATE INDEX IF NOT EXISTS `index_user_statistic_studio_studio_id` ON `user_statistic_studio` (`studio_id`)",
+                "CREATE INDEX IF NOT EXISTS `index_user_statistic_tag_tag_id` ON `user_statistic_tag` (`tag_id`)",
+                "CREATE INDEX IF NOT EXISTS `index_user_statistic_voice_actor_staff_id` ON `user_statistic_voice_actor` (`staff_id`)",
+                "CREATE INDEX IF NOT EXISTS `index_user_profile_favourite_media_media_id` ON `user_profile_favourite_media` (`media_id`)",
+                "CREATE INDEX IF NOT EXISTS `index_user_profile_review_review_id` ON `user_profile_review` (`review_id`)",
+                "CREATE INDEX IF NOT EXISTS `index_user_profile_review_media_id` ON `user_profile_review` (`media_id`)",
+            )
+        },
     )

--- a/data/src/main/kotlin/co/anitrend/data/common/model/paging/query/PageQuery.kt
+++ b/data/src/main/kotlin/co/anitrend/data/common/model/paging/query/PageQuery.kt
@@ -27,7 +27,7 @@ import co.anitrend.arch.extension.util.pagination.contract.ISupportPagingHelper
 
 internal data class PageQuery(
     var page: Int,
-    @IntRange(from = 0, to = 50)
+    @param:IntRange(from = 0, to = 50)
     val perPage: Int = 30,
 ) : ISupportPagingHelper {
     /**

--- a/data/src/main/kotlin/co/anitrend/data/user/converter/UserProfileOverviewConverter.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/converter/UserProfileOverviewConverter.kt
@@ -60,7 +60,7 @@ internal object UserProfileOverviewConverter {
             episodes = source.episodes ?: 0,
             chapters = source.chapters ?: 0,
             volumes = source.volumes ?: 0,
-            isFavourite = source.isFavourite ?: false,
+            isFavourite = source.isFavourite,
             meanScore = source.meanScore ?: 0,
             averageScore = source.averageScore ?: 0,
             siteUrl = source.siteUrl,

--- a/data/src/main/kotlin/co/anitrend/data/user/entity/connection/UserProfileFavouriteMediaEntity.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/entity/connection/UserProfileFavouriteMediaEntity.kt
@@ -38,6 +38,7 @@ import co.anitrend.support.query.builder.annotation.EntitySchema
     indices = [
         Index(value = ["user_id", "media_id", "category"], unique = true),
         Index(value = ["user_id", "sort_index"]),
+        Index(value = ["media_id"]),
     ],
     foreignKeys = [
         ForeignKey(

--- a/data/src/main/kotlin/co/anitrend/data/user/entity/connection/UserProfileReviewEntity.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/entity/connection/UserProfileReviewEntity.kt
@@ -43,6 +43,8 @@ import co.anitrend.support.query.builder.annotation.EntitySchema
     indices = [
         Index(value = ["user_id", "review_id", "media_id"], unique = true),
         Index(value = ["user_id", "sort_index"]),
+        Index(value = ["review_id"]),
+        Index(value = ["media_id"]),
     ],
     foreignKeys = [
         ForeignKey(

--- a/data/src/main/kotlin/co/anitrend/data/user/entity/statistic/UserStatisticDimensions.kt
+++ b/data/src/main/kotlin/co/anitrend/data/user/entity/statistic/UserStatisticDimensions.kt
@@ -242,7 +242,7 @@ internal data class UserStatisticStatusEntity(
 
 @Entity(
     tableName = "user_statistic_staff",
-    indices = [Index(value = ["user_id", "media_type", "staff_id"], unique = true)],
+    indices = [Index(value = ["user_id", "media_type", "staff_id"], unique = true), Index(value = ["staff_id"])],
     foreignKeys = [
         ForeignKey(
             entity = UserEntity::class,
@@ -274,7 +274,7 @@ internal data class UserStatisticStaffEntity(
 
 @Entity(
     tableName = "user_statistic_studio",
-    indices = [Index(value = ["user_id", "media_type", "studio_id"], unique = true)],
+    indices = [Index(value = ["user_id", "media_type", "studio_id"], unique = true), Index(value = ["studio_id"])],
     foreignKeys = [
         ForeignKey(
             entity = UserEntity::class,
@@ -306,7 +306,7 @@ internal data class UserStatisticStudioEntity(
 
 @Entity(
     tableName = "user_statistic_tag",
-    indices = [Index(value = ["user_id", "media_type", "tag_id"], unique = true)],
+    indices = [Index(value = ["user_id", "media_type", "tag_id"], unique = true), Index(value = ["tag_id"])],
     foreignKeys = [
         ForeignKey(
             entity = UserEntity::class,
@@ -338,7 +338,7 @@ internal data class UserStatisticTagEntity(
 
 @Entity(
     tableName = "user_statistic_voice_actor",
-    indices = [Index(value = ["user_id", "media_type", "staff_id"], unique = true)],
+    indices = [Index(value = ["user_id", "media_type", "staff_id"], unique = true), Index(value = ["staff_id"])],
     foreignKeys = [
         ForeignKey(
             entity = UserEntity::class,


### PR DESCRIPTION
## Description

Resolves three categories of KSP/Kotlin compile warnings in the `:data` module.

### Room FK Index Warnings (7 warnings)
Room KSP warns when foreign key columns lack standalone indices, triggering full table scans on parent table modifications during cascade operations. Six entities in `:data:user` had FK columns (`staff_id`, `studio_id`, `tag_id`, `review_id`, `media_id`) that only appeared as non-leftmost columns in composite unique indices, making them invisible to SQLite for FK cascade checks.

An audit of all 34 entities with `foreignKeys` confirmed 28 already follow the correct pattern (standalone `Index(value = ["column"])` per FK). This fix brings the remaining 6 into compliance.

### Kotlin 2.x Annotation Target (1 warning)
`PageQuery.kt` — `@IntRange` on a data class constructor parameter is ambiguous in Kotlin 2.x. Explicit `@param:IntRange` preserves current behavior. Ref: KT-73255

### Dead Elvis Operator (1 warning)
`UserProfileOverviewConverter.kt` — `source.isFavourite ?: false` where `MediaEntity.isFavourite` is non-nullable `Boolean`. Removed dead code.

### Changes
- 7 new standalone FK indices in 3 entity files
- Schema version bump 23 → 24 with manual `migrationOfStatements(23, 24)`
- v23→24 migration test verifying all 7 indices
- Schema export to `data/schemas/.../24.json`
- Annotation target fix in `PageQuery.kt`
- Dead code removal in `UserProfileOverviewConverter.kt`

### Verification
| Check | Result |
|---|---|
| `./gradlew :data:compileDebugKotlin` | BUILD SUCCESSFUL, zero targeted warnings |
| `./gradlew :data:testDebugUnitTest` | BUILD SUCCESSFUL, 165 tasks |
| `./gradlew spotlessApply` | BUILD SUCCESSFUL |
| `./gradlew lint` | (pending) |
| `./gradlew :data:compileDebugKotlin` (full rebuild) | (pending) |
| Schema export (24.json) | All 7 CREATE INDEX IF NOT EXISTS confirmed |

Ref: #1271

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (Improves existing functionality)

<!--- Be kind to code reviewers, and please try to keep pull requests as small and focused as possible :) -->

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [GPL v3 License](https://github.com/AniTrend/anitrend-v2/blob/develop/LICENSE.md).